### PR TITLE
https://github.com/persan/auto-io-gen/issues/1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PREFIX?=${CURDIR}/_
 all: compile test
 
 compile:
-	gprbuild -P auto_io_gen.gpr -XASIS_BUILD=default -j0 -p -k
+	gprbuild -P auto_io_gen.gpr -XASIS_BUILD=static -j0 -p -k
 test:
 	${MAKE} -C tests all
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # auto-io-gen
 Generate io Ada packages for tex JSON,XML,Simple Image, .....
+
+To build, type "make".

--- a/src/auto_io_gen-driver.adb
+++ b/src/auto_io_gen-driver.adb
@@ -24,6 +24,7 @@ with Ada.Strings.Maps;
 with Ada.Strings.Wide_Unbounded;
 with Ada.Text_IO;      use Ada.Text_IO;
 with Ada.Wide_Text_IO;
+with GNAT.Command_Line;
 with Asis.Ada_Environments;
 with Asis.Aux;
 with Asis.Compilation_Units;
@@ -214,6 +215,14 @@ exception
          Put_Line ("ASIS Error");
          Ada.Wide_Text_IO.Put_Line (Asis.Implementation.Diagnosis);
       end if;
+
+   when GNAT.Command_Line.Exit_From_Command_Line =>
+      New_Line;
+      Put_Line ("Auto_Io_Gen: illegal command line. Run with -d option for more info.");
+
+      Auto_Io_Gen.Options.Clean_Up;
+
+      Ada.Command_Line.Set_Exit_Status (Ada.Command_Line.Failure);
 
    when E : others =>
       New_Line;

--- a/src/auto_io_gen-options.adb
+++ b/src/auto_io_gen-options.adb
@@ -53,6 +53,9 @@ package body Auto_Io_Gen.Options is
    Overwrite_Tree : aliased Boolean := True;
    --  Should an existing tree file be overwritten
 
+   Parser_Was_Set_Up : Boolean := False;
+   -- Auxiliary flag for avoiding double execution of Setup_Parser
+
    Reuse_Tree : aliased Boolean := False;
    --  Should an existing tree file be reused
 
@@ -131,20 +134,24 @@ package body Auto_Io_Gen.Options is
    procedure Setup_Parser is
       use GNAT.Command_Line;
    begin
+      if Parser_Was_Set_Up then
+         return;
+      end if;
+
       Define_Switch (Command_Line_Parser, Debug'Access, "-d", "--debug", "debug output");
       Define_Switch (Command_Line_Parser, Verbose'Access, "-v", "--verbose", "verbose output");
       Define_Switch (Command_Line_Parser, Overwrite_Child'Access, "-f", "", "Replace existing files");
-      Define_Switch (Command_Line_Parser, Quiet'Access, "-q", "", "Quite mode");
-      Define_Switch (Command_Line_Parser, Quiet'Access, "-o", "", "Set Output Directory");
+      Define_Switch (Command_Line_Parser, Quiet'Access, "-q", "", "Quiet mode");
       Define_Switch (Command_Line_Parser, Create_Output_Folders'Access, "-o", "", "Set Output Directory");
       Define_Switch (Command_Line_Parser, Project_Arg'Access, "-P", "", "Use project file");
       Define_Switch (Command_Line_Parser, Overwrite_Child'Access, "-t", "", "overwrite the existing tree file");
       Define_Switch (Command_Line_Parser, Delete_Tree'Access, "-k", "", "do not remove the GNAT tree file", Value => False);
       Define_Switch (Command_Line_Parser, Reuse_Tree'Access, "-r", "", "reuse the GNAT tree file instead of re-creating it (-r also implies -k)");
-      Define_Switch (Command_Line_Parser, Indent'Access, "-i=", "", "(N in 1 .. 9) number of spaces used for identation in generated code.");
+      Define_Switch (Command_Line_Parser, Indent'Access, "-i=", "", "(N in 1 .. 9) number of spaces used for indentation in generated code.");
       Define_Switch (Command_Line_Parser, Trace_Exceptions'Access, "-T", "", "Trace all exceptions.");
       Define_Switch (Command_Line_Parser, Create_Output_Folders'Access, "-p", "", "Create Output Folders.");
 
+      Parser_Was_Set_Up := True;
    end;
 
    procedure Check_Parameters


### PR DESCRIPTION
Apply attachment [auto-io-gen-c5476d5f-build-using-gnat-community-2019.diff](https://github.com/persan/auto-io-gen/files/4351394/auto-io-gen-c5476d5f-build-using-gnat-community-2019.diff.gz) :

README.md
- Mention how to build this software.

Makefile
- At rule `compile` change -XASIS_BUILD=default to -XASIS_BUILD=static.

src/auto_io_gen-driver.adb
- Handle the exception GNAT.Command_Line.Exit_From_Command_Line to give
  a reasonable error message.

src/auto_io_gen-options.adb
- Add a flag Parser_Was_Set_Up to prevent the duplicated help text
  on calling procedure Setup_Parser twice.
- In procedure Setup_Parser remove duplicated call to Define_Switch for
  option "-o".