### PR TITLE
Fix for indentation of generated code plus small cosmetic improvements

### DIFF
--- a/src/auto_io_gen-build-process_element_do_package.adb
+++ b/src/auto_io_gen-build-process_element_do_package.adb
@@ -128,7 +128,13 @@ begin
 
          when others =>
             Debug.Put_Line (Processing);
-            Report_Unsupported (State, Element);
+            declare
+               D_Kind : constant Asis.Declaration_Kinds
+                      := Elements.Declaration_Kind (Element);
+            begin
+               Report_Unsupported
+                 (State, Element, Asis.Declaration_Kinds'Image (D_Kind));
+            end;
             Control := Abandon_Children;
          end case;
       end if;

--- a/src/auto_io_gen-build-process_element_do_type.adb
+++ b/src/auto_io_gen-build-process_element_do_type.adb
@@ -27,7 +27,6 @@ procedure Auto_Io_Gen.Build.Process_Element_Do_Type
    State   : in out State_Type)
 is
    use Asis;
-   use type Lists.Type_Descriptor_Access_Type;
 begin
    Debug.Put_Line ("Element =>" & Elements.Element_Kind (Element)'Img & ", State => " & State.Private_State.Label'Img);
 
@@ -311,14 +310,22 @@ begin
 
          when others =>
             Debug.Put_Line ( Skipping);
-            Report_Unsupported (State, Element);
+            declare
+               Kind : constant Asis.Type_Kinds := Elements.Type_Kind (Element);
+            begin
+               Report_Unsupported (State, Element, Asis.Type_Kinds'Image (Kind));
+            end;
             Control := Abandon_Siblings;
 
          end case;
 
       when others =>
          Debug.Put_Line (Skipping);
-         Report_Unsupported (State, Element);
+         declare
+            Kind : constant Definition_Kinds := Elements.Definition_Kind (Element);
+         begin
+            Report_Unsupported (State, Element, Definition_Kinds'Image (Kind));
+         end;
          Control := Abandon_Siblings;
 
       end case; --  Definition_Kinds

--- a/src/auto_io_gen-build-process_element_utils.adb
+++ b/src/auto_io_gen-build-process_element_utils.adb
@@ -707,7 +707,7 @@ package body Auto_Io_Gen.Build.Process_Element_Utils is
            Trim (Character_Position_Positive'Image (El_Span.First_Column), Left) & ": " &
            Program_Name & ": " &
            Message &
-           "not supported");
+           " not supported");
 
       if Options.Error_On_Warn then
          State.Error_Count := State.Error_Count + 1;

--- a/src/auto_io_gen-driver.adb
+++ b/src/auto_io_gen-driver.adb
@@ -45,26 +45,26 @@ procedure Auto_Io_Gen.Driver
 is
 begin
 
-   OPtions.Read_Command_Line;
+   Options.Read_Command_Line;
 
 
-   if OPtions.Verbose then
+   if Options.Verbose then
       Put_Line (Version);
       Put_Line ("GNAT version (from ASIS) " & Gnatvsn.Gnat_Version_String);
       New_Line;
    end if;
 
    --  Compile the Asis context if necessary.
-   OPtions.Initialize;
+   Options.Initialize;
 
-   if not OPtions.Initialized then
+   if not Options.Initialized then
       --  Error message already output.
       Ada.Command_Line.Set_Exit_Status (Ada.Command_Line.Failure);
       return;
    end if;
 
-   if OPtions.Verbose then
-      Put_Line ("Package_File_Name => " & OPtions.Package_File_Name.all);
+   if Options.Verbose then
+      Put_Line ("Package_File_Name => " & Options.Package_File_Name.all);
    end if;
 
    declare
@@ -105,14 +105,14 @@ begin
       CU_Kind := Asis.Compilation_Units.Unit_Kind (CU);
 
       if Is_Nil (CU) then
-         Put_Line ("file " & OPtions.Package_File_Name.all & " does not contain a unit to create a Text_IO child for");
+         Put_Line ("file " & Options.Package_File_Name.all & " does not contain a unit to create a Text_IO child for");
          Asis_Clean_Up;
 
       elsif not (CU_Kind = A_Package or else
                  CU_Kind = A_Generic_Package)
       then
 
-         if not OPtions.Quiet then
+         if not Options.Quiet then
             Ada.Wide_Text_IO.Put ("Auto_Io_Gen: Compilation unit " & Unit_Full_Name (CU));
             Put_Line (" does not require a Text_IO child");
             Put_Line (" Unit Kind: " & Unit_Kinds'Image (CU_Kind));

--- a/src/auto_io_gen-options.adb
+++ b/src/auto_io_gen-options.adb
@@ -146,8 +146,10 @@ package body Auto_Io_Gen.Options is
       Define_Switch (Command_Line_Parser, Project_Arg'Access, "-P", "", "Use project file");
       Define_Switch (Command_Line_Parser, Overwrite_Child'Access, "-t", "", "overwrite the existing tree file");
       Define_Switch (Command_Line_Parser, Delete_Tree'Access, "-k", "", "do not remove the GNAT tree file", Value => False);
-      Define_Switch (Command_Line_Parser, Reuse_Tree'Access, "-r", "", "reuse the GNAT tree file instead of re-creating it (-r also implies -k)");
-      Define_Switch (Command_Line_Parser, Indent'Access, "-i=", "", "(N in 1 .. 9) number of spaces used for indentation in generated code.");
+      Define_Switch (Command_Line_Parser, Reuse_Tree'Access, "-r", "",
+                     "reuse the GNAT tree file instead of re-creating it (-r also implies -k)");
+      Define_Switch (Command_Line_Parser, Indent'Access, "-i=", "",
+                     "(N in 1 .. 9) number of spaces used for indentation in generated code.", Initial => Indent);
       Define_Switch (Command_Line_Parser, Trace_Exceptions'Access, "-T", "", "Trace all exceptions.");
       Define_Switch (Command_Line_Parser, Create_Output_Folders'Access, "-p", "", "Create Output Folders.");
 

--- a/src/auto_io_gen.adb
+++ b/src/auto_io_gen.adb
@@ -217,10 +217,10 @@ package body Auto_Io_Gen is
    is
       use Ada.Text_IO;
    begin
-
       --  Indent 0 means column 1
       Set_Col (File, 1 + Count (Auto_Io_Gen.Options.Indent) * (Count (Indent_Level) - 1));
    end Set_Indent;
+
    function Ada2file (Name : String) return String is
       Map : constant Ada.Strings.Maps.Character_Mapping :=
               Ada.Strings.Maps.To_Mapping ("ABCDEFGHIJKLMNOPQRSTUVWXYZ.",

--- a/src/auto_io_gen.ads
+++ b/src/auto_io_gen.ads
@@ -42,7 +42,7 @@ package Auto_Io_Gen is
    --  How text_io child package name is used; in an expression with
    --  Put or Get, as a generic formal parameter, as a generic unit in
    --  a generic formal package declaration, or in a with clause. This
-   --  affects the naming convetion used by Text_IO_Child_Name.
+   --  affects the naming convention used by Text_IO_Child_Name.
 
    function Text_IO_Child_Name
      (Package_Declaration : in Asis.Element;
@@ -64,10 +64,14 @@ package Auto_Io_Gen is
    --  do "with, use" for the private children, and they never appear
    --  as a generic formal parameter, so no "Label" parameter is
    --  needed.
+
    Not_Implemented : exception;
    Not_Found       : exception;
+
    procedure Set_Indent (File : in Ada.Text_IO.File_Type);
    Indent_Level : Ada.Text_IO.Positive_Count := 1;
    --  1 is no indentation.
+
    function Ada2file (Folder, Name , Suffix : String) return String;
+
 end Auto_Io_Gen;


### PR DESCRIPTION
Commit 41127d0 fixes the indenting mechanism for the generated code.
Commit 69c4752 makes small readability improvements.
Commit cc943fd adds printing of offending value in a few of the "not supported" errors.