### PR TITLE
Reduce visual clutter on closely related consecutive calls to Indent_Line

### DIFF
--- a/src/text_io/auto_io_gen-generate-get_body.adb
+++ b/src/text_io/auto_io_gen-generate-get_body.adb
@@ -155,10 +155,10 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
+      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "is begin");
@@ -197,9 +197,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
+      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -211,9 +211,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -311,10 +311,10 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
 
@@ -343,9 +343,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
@@ -369,9 +369,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -392,10 +392,10 @@ package body Auto_Io_Gen.Generate.Get_Body is
       is begin
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                            " Named_Association_Record    : in     Boolean := False;",
+                            " Named_Association_Component : in     Boolean := False)");
 
          Indent_Level := Indent_Level - 1;
       end Print_Parameter_List;
@@ -611,9 +611,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -625,9 +625,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");

--- a/src/text_io/auto_io_gen-generate-put_body.adb
+++ b/src/text_io/auto_io_gen-generate-put_body.adb
@@ -109,10 +109,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Body_First := False;
       end if;
 
-      Indent_Line (File, "if Named_Association_Record then");
-      Indent_Line (File, "   Put (File, """ & Component_Name & " => "");");
-      Indent_Line (File, "   if not Single_Line_Component then New_Line (File); end if;");
-      Indent_Line (File, "end if;");
+      Indent_Line (File, "if Named_Association_Record then",
+                         "   Put (File, """ & Component_Name & " => "");",
+                         "   if not Single_Line_Component then New_Line (File); end if;",
+                         "end if;");
 
       if Asis.Elements.Is_Nil (Component.Type_Package) then
          if Component.Invisible then
@@ -145,12 +145,12 @@ package body Auto_Io_Gen.Generate.Put_Body is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False)");
+      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "is begin");
@@ -186,11 +186,11 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False)");
+      Indent_Line (File, "(Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -204,10 +204,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False)");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -287,12 +287,12 @@ package body Auto_Io_Gen.Generate.Put_Body is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False)");
+      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
 
@@ -323,11 +323,11 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False)");
+      Indent_Line (File, "(Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
@@ -358,10 +358,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False)");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       Indent_Line (File, "is begin");
@@ -398,13 +398,13 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Put_Line (File, "Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
 
          if Is_Item then
-            Indent_Line (File, " Single_Line                 : in Boolean := False;");
-            Indent_Line (File, " Named_Association           : in Boolean := False)");
+            Indent_Line (File, " Single_Line                 : in Boolean := False;",
+                               " Named_Association           : in Boolean := False)");
          else
-            Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-            Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-            Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-            Indent_Line (File, " Named_Association_Component : in Boolean := False)");
+            Indent_Line (File, " Single_Line_Record          : in Boolean := True;",
+                               " Named_Association_Record    : in Boolean := False;",
+                               " Single_Line_Component       : in Boolean := True;",
+                               " Named_Association_Component : in Boolean := False)");
          end if;
 
          Indent_Level := Indent_Level - 1;

--- a/src/text_io/auto_io_gen-generate-spec.adb
+++ b/src/text_io/auto_io_gen-generate-spec.adb
@@ -214,6 +214,7 @@ package body Auto_Io_Gen.Generate.Spec is
       is
          pragma Unreferenced (Type_List);
       begin
+         Indent_Level := 1;
          Put_Line (File, "end " & Child_Package_Name & ";");
       end Print_Footer;
 
@@ -405,14 +406,14 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                      : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array;");
-         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                      : in " & Type_Name & ";",
+                            " Single_Line_Array         : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association_Array   : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array;",
+                            " Single_Line_Element       : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
@@ -427,13 +428,13 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array;");
-         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(Item                : in " & Type_Name & ";",
+                            " Single_Line_Array         : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association_Array   : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array;",
+                            " Single_Line_Element       : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
@@ -448,20 +449,20 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Put_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                 : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line          : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association    : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array)");
-         Indent_Line (File, "renames " & Package_Name & ".Put_Item;");
+         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                 : in " & Type_Name & ";",
+                            " Single_Line          : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association    : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array)",
+                            "renames " & Package_Name & ".Put_Item;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
+         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                      :    out " & Type_Name & ";",
+                            " Named_Association_Array   : in     Boolean :=");
          Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Level := Indent_Level - 1;
@@ -474,8 +475,8 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
+         Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
+                            " Named_Association_Array   : in     Boolean :=");
          Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Level := Indent_Level - 1;
@@ -488,10 +489,10 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Get_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item              :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association : in     Boolean := False)");
-         Indent_Line (File, "renames " & Package_Name & ".Get_Item;");
+         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                            " Item              :    out " & Type_Name & ";",
+                            " Named_Association : in     Boolean := False)",
+                            "renames " & Package_Name & ".Get_Item;");
          Indent_Level := Indent_Level - 1;
 
       when Lists.Enumeration_Label =>
@@ -528,31 +529,31 @@ package body Auto_Io_Gen.Generate.Spec is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                      : in " & Type_Name & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                      : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(Item                      : in " & Type_Name & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
@@ -560,24 +561,24 @@ package body Auto_Io_Gen.Generate.Spec is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
+      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                      :    out " & Type_Name & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
+      Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False);");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
 
       New_Line (File);
@@ -632,30 +633,30 @@ package body Auto_Io_Gen.Generate.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
@@ -663,24 +664,24 @@ package body Auto_Io_Gen.Generate.Spec is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False);");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
 
       New_Line (File);
@@ -706,42 +707,42 @@ package body Auto_Io_Gen.Generate.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       if Type_Descriptor.Record_Tagged then
          Indent_Level := Indent_Level - 1;
          Indent_Line (File, "procedure Put_Components");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-         Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-         Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-         Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                        : in " & Type_Name & ";",
+                            " Single_Line_Record          : in Boolean := True;",
+                            " Named_Association_Record    : in Boolean := False;",
+                            " Single_Line_Component       : in Boolean := True;",
+                            " Named_Association_Component : in Boolean := False);");
 
       end if;
 
@@ -751,34 +752,34 @@ package body Auto_Io_Gen.Generate.Spec is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Type_Name & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False);");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Record_Tagged then
          Indent_Line (File, "procedure Get_Components");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                        :    out " & Type_Name & ";",
+                            " Named_Association_Record    : in     Boolean := False;",
+                            " Named_Association_Component : in     Boolean := False);");
          Indent_Level := Indent_Level - 1;
       end if;
 

--- a/src/text_io/auto_io_gen-generate.adb
+++ b/src/text_io/auto_io_gen-generate.adb
@@ -33,7 +33,7 @@
 --  3) Record types declared in the private part: generate
 --     Private_Text_IO child package.
 --
---  4) Record types with discriminants, with no defaults. Here we call
+--  4) Record types with discriminants, with defaults. Here we call
 --     these "Constrained_Discriminants". Since the Item parameter is
 --     constrained, we can just compare the discriminants read from the
 --     file with the constraints, and raise Discriminant_Error for a
@@ -322,10 +322,56 @@ package body Auto_Io_Gen.Generate is
       Ada.Text_IO.Put (File, Text);
    end Indent;
 
-   procedure Indent_Line (File : in Ada.Text_IO.File_Type; Text : in String)
+   procedure Indent_Line (File : in Ada.Text_IO.File_Type;
+                          Text  : in String;
+                          Text1 : in String := "";
+                          Text2 : in String := "";
+                          Text3 : in String := "";
+                          Text4 : in String := "";
+                          Text5 : in String := "";
+                          Text6 : in String := "";
+                          Text7 : in String := "";
+                          Text8 : in String := "";
+                          Text9 : in String := "")
    is begin
       Set_Indent (File);
       Ada.Text_IO.Put_Line (File, Text);
+      if Text1 /= "" then
+      Set_Indent (File);
+         Ada.Text_IO.Put_Line (File, Text1);
+         if Text2 /= "" then
+            Set_Indent (File);
+            Ada.Text_IO.Put_Line (File, Text2);
+            if Text3 /= "" then
+               Set_Indent (File);
+               Ada.Text_IO.Put_Line (File, Text3);
+               if Text4 /= "" then
+                  Set_Indent (File);
+                  Ada.Text_IO.Put_Line (File, Text4);
+                  if Text5 /= "" then
+                     Set_Indent (File);
+                     Ada.Text_IO.Put_Line (File, Text5);
+                     if Text6 /= "" then
+                        Set_Indent (File);
+                        Ada.Text_IO.Put_Line (File, Text6);
+                        if Text7 /= "" then
+                           Set_Indent (File);
+                           Ada.Text_IO.Put_Line (File, Text7);
+                           if Text8 /= "" then
+                              Set_Indent (File);
+                              Ada.Text_IO.Put_Line (File, Text8);
+                              if Text9 /= "" then
+                                 Set_Indent (File);
+                                 Ada.Text_IO.Put_Line (File, Text9);
+                              end if;
+                           end if;
+                        end if;
+                     end if;
+                  end if;
+               end if;
+            end if;
+         end if;
+      end if;
    end Indent_Line;
 
    function Instantiated_Package_Name (Type_Name : in String) return String
@@ -451,6 +497,7 @@ package body Auto_Io_Gen.Generate is
       return Type_Name (Type_Name'First .. Root_Name_Index);
 
    end Root_Type_Name;
+
    function Standard_Text_IO_Name (Type_Name : in String) return String
    is begin
       if Type_Name = "boolean" then
@@ -497,7 +544,7 @@ package body Auto_Io_Gen.Generate is
       elsif Type_Name = "wide_wide_character" then
          return "Auto_Text_Io.Wide_Wide_Text_IO";
       else
-         Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, "Unsuported type:  " & Type_Name);
+         Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, "Unsupported type:  " & Type_Name);
          raise Not_Supported with Type_Name;
       end if;
 

--- a/src/text_io/auto_io_gen-generate.ads
+++ b/src/text_io/auto_io_gen-generate.ads
@@ -37,9 +37,6 @@ private
 
    --  Visible for child packages.
 
-   Indent_Level : Ada.Text_IO.Positive_Count := 1;
-   --  1 is no indentation.
-
    function Ada_Text_IO return String;
    --  Return package name appropriate for Ada 83 or Ada 95, as
    --  determined by Options.Ada_83.
@@ -57,7 +54,17 @@ private
    procedure Indent (File : in Ada.Text_IO.File_Type; Text : in String);
    --  Do Set_Indent (File), then Put (File, Text).
 
-   procedure Indent_Line (File : in Ada.Text_IO.File_Type; Text : in String);
+   procedure Indent_Line (File : in Ada.Text_IO.File_Type;
+                          Text  : in String;
+                          Text1 : in String := "";
+                          Text2 : in String := "";
+                          Text3 : in String := "";
+                          Text4 : in String := "";
+                          Text5 : in String := "";
+                          Text6 : in String := "";
+                          Text7 : in String := "";
+                          Text8 : in String := "";
+                          Text9 : in String := "");
    --  Do Set_Indent (File), then Put_Line (File, Text).
 
    procedure Instantiate_Generic_Array_Text_IO


### PR DESCRIPTION
The repetitive calls to Indent_Line tend to add visual clutter.
Here is a small step for somewhat reducing the repetitions.
The procedure Indent_Line gets some optional Text arguments so that multiple lines may be printed using a single call.