### PR TITLE
Further uncluttering related to use of Indent_Level / Indent_Line

### DIFF
--- a/src/text_io/auto_io_gen-generate-get_body.adb
+++ b/src/text_io/auto_io_gen-generate-get_body.adb
@@ -141,9 +141,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Indent_Line (File, "Get (File, Temp_Item." & Component_Name & ");");
       else
          Indent_Line (File, "Get_Item (File, Temp_Item." & Component_Name & ",");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "Named_Association => Named_Association_Component);");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, "Named_Association => Named_Association_Component);");
       end if;
 
    end Generate_Component_Temp_Get;
@@ -160,9 +158,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
                          " Named_Association_Array   : in     Boolean := False;",
                          " Named_Association_Element : in     Boolean := False)");
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
 
       if Asis.Elements.Is_Nil (Type_Descriptor.Derived_Root_Package_Declaration) then
          Indent_Line (File, "Get");
@@ -195,32 +191,22 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
       Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Named_Association_Array   : in     Boolean := False;",
                          " Named_Association_Element : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Array, Named_Association_Element);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get_Item");
       Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
                          " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
    end Generate_Derived_Array;
 
@@ -293,9 +279,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
               Discriminant_Name &
               ") then");
       end if;
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "raise Discriminant_Error;");
-      Indent_Level := Indent_Level - 1;
+      Indent_More (File, "raise Discriminant_Error;");
       Indent_Line (File, "end if;");
 
    end Generate_Discriminant_Compare;
@@ -308,8 +292,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
    begin
       --  Generic_Array_IO was instantiated by Put_Body.
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
 
       Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
                          " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
@@ -337,8 +320,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get");
@@ -350,7 +332,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
          Indent_Line (File, "is");
-         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
+         Indent_More (File, "pragma Unreferenced (Named_Association_Component);");
          Indent_Line (File, "begin");
       else
          Indent_Line (File, "is begin");
@@ -363,8 +345,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
       else
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get_Item");
@@ -372,13 +353,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
                          " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, Package_Name & ".Get_Item (File, Item, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
    end Generate_Private_Array_Wrapper;
 
@@ -527,9 +504,7 @@ package body Auto_Io_Gen.Generate.Get_Body is
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
          end if;
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Less (File, "begin");
 
          Body_First := True;
 
@@ -542,17 +517,14 @@ package body Auto_Io_Gen.Generate.Get_Body is
          if Type_Descriptor.Record_Constrained then
             Print_Discriminant_Compares (Type_Descriptor.Record_Discriminants);
          else
-            Indent_Line (File, "declare");
-            Indent_Level := Indent_Level + 1;
+            Indent_Incr (File, "declare");
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name));
             Indent_Level := Indent_Level + 1;
             Indent (File, "(");
             Print_Discriminants (Type_Descriptor.Record_Discriminants);
             Put_Line (File, ");");
             Indent_Level := Indent_Level - 1;
-            Indent_Level := Indent_Level - 1;
-            Indent_Line (File, "begin");
-            Indent_Level := Indent_Level + 1;
+            Indent_Less (File, "begin");
          end if;
 
          if Type_Descriptor.Record_Derived then
@@ -568,16 +540,16 @@ package body Auto_Io_Gen.Generate.Get_Body is
               (File,
                Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  ".Text_IO.Get_Components");
+            Indent_Level := Indent_Level + 1;
             Indent_Line
               (File,
                " (File, " &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  "." &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Type_Name) &
-                 " (Temp_Item),");
-            Indent_Line
-              (File,
+                 " (Temp_Item),",
                "Named_Association_Record, Named_Association_Component);");
+            Indent_Level := Indent_Level - 1;
          end if;
 
          if Type_Descriptor.Record_Tagged then
@@ -598,43 +570,31 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
          if not Type_Descriptor.Record_Constrained then
             Indent_Line (File, "Item := Temp_Item;");
-            Indent_Level := Indent_Level - 1;
-            Indent_Line (File, "end;");
+            Indent_Decr (File, "end;");
          end if;
 
          Indent_Line (File, "Check (File, "")"");");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Get;");
+         Indent_Decr (File, "end Get;");
          New_Line (File);
 
       end if;
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
       Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Named_Association_Record    : in     Boolean := False;",
                          " Named_Association_Component : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Record, Named_Association_Component);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get_Item");
       Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
                          " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
 
       if Type_Descriptor.Record_Tagged then
@@ -642,17 +602,14 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Print_Parameter_List;
 
          Indent_Line (File, "is");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
          Indent_Line (File, "begin");
          Indent_Level := Indent_Level + 1;
 
          Body_First := True;
          Print_Component_Gets (Type_Descriptor.Record_Components);
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Get_Components;");
+         Indent_Decr (File, "end Get_Components;");
          New_Line (File);
       end if;
 

--- a/src/text_io/auto_io_gen-generate-put_body.adb
+++ b/src/text_io/auto_io_gen-generate-put_body.adb
@@ -100,10 +100,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
          --  Finish last component put
          Indent_Line
             (File,
-             "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
+             "Put (File, Character' (',')); if not Single_Line_Record then New_Line (File); end if;");
 
          --  Start current component put
-         Indent (File, "Put (File, Character'(' '));");
+         Indent (File, "Put (File, Character' (' '));");
 
       else
          Body_First := False;
@@ -128,12 +128,9 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Put_Line (File, "Put (File, Item." & Component_Name & ");");
       else
          Put_Line (File, "Put_Item (File, Item." & Component_Name & ",");
-         Indent_Level := Indent_Level + 1;
-
-         Indent_Line
+         Indent_More
             (File,
              "Single_Line => Single_Line_Component, Named_Association => Named_Association_Component);");
-         Indent_Level := Indent_Level - 1;
       end if;
 
    end Generate_Component_Line;
@@ -142,8 +139,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
       (File            : in Ada.Text_IO.File_Type;
        Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
    is begin
-      Indent_Line (File, "procedure Put");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put");
 
       Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
                          " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
@@ -152,9 +148,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
                          " Single_Line_Element       : in Boolean := True;",
                          " Named_Association_Element : in Boolean := False)");
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
 
       if Asis.Elements.Is_Nil (Type_Descriptor.Derived_Root_Package_Declaration) then
          Indent (File, "Put");
@@ -180,41 +174,30 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line
         (File, " Single_Line_Array, Named_Association_Array, Single_Line_Element, Named_Association_Element);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put;");
+      Indent_Decr (File, "end Put;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Put");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put");
       Indent_Line (File, "(Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Single_Line_Array         : in Boolean := False;",
                          " Named_Association_Array   : in Boolean := False;",
                          " Single_Line_Element       : in Boolean := True;",
                          " Named_Association_Element : in Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Put (Current_Output, Item,");
       Indent_Line
         (File, "     Single_Line_Array, Named_Association_Array, Single_Line_Element, Named_Association_Element);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put;");
+      Indent_Decr (File, "end Put;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Put_Item");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put_Item");
       Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
                          " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Single_Line       : in Boolean := False;",
                          " Named_Association : in Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Put (File, Item, Single_Line, Named_Association, Single_Line, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put_Item;");
+      Indent_Decr (File, "end Put_Item;");
       New_Line (File);
    end Generate_Derived_Array;
 
@@ -231,61 +214,46 @@ package body Auto_Io_Gen.Generate.Put_Body is
          null;
 
       when Lists.Enumeration_Label =>
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Width (Width : in Ada.Text_IO.Field)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Width (Width : in Ada.Text_IO.Field)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Width := Width;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Width;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Width;");
 
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Setting (Setting : in Ada.Text_IO.Type_Set)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Setting (Setting : in Ada.Text_IO.Type_Set)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Setting := Setting;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Setting;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Setting;");
 
       when Lists.Float_Label =>
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Fore (Fore : in Ada.Text_IO.Field)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Fore (Fore : in Ada.Text_IO.Field)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Fore := Fore;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Fore;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Fore;");
 
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Aft (Aft : in Ada.Text_IO.Field)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Aft (Aft : in Ada.Text_IO.Field)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Aft := Aft;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Aft;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Aft;");
 
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Exp (Exp : in Ada.Text_IO.Field)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Exp (Exp : in Ada.Text_IO.Field)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Exp := Exp;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Exp;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Exp;");
 
       when Lists.Signed_Integer_Label | Lists.Modular_Integer_Label =>
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Width (Width : Ada.Text_IO.Field)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Width (Width : Ada.Text_IO.Field)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Width := Width;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Width;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Width;");
 
-         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Base (Base : Ada.Text_IO.Number_Base)");
-         Indent_Line (File, "is begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Base (Base : Ada.Text_IO.Number_Base)");
+         Indent_Less (File, "is begin");
          Indent_Line (File, Package_Name & ".Default_Base := Base;");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Set_" & Package_Name & "_Default_Base;");
+         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Base;");
 
       end case;
 
-      Indent_Line (File, "procedure Put");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put");
 
       Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
                          " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
@@ -297,10 +265,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
-         Indent_Line (File, "is");
-         Indent_Line (File, "   pragma Unreferenced (Single_Line_Component);");
-         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
-         Indent_Line (File, "begin");
+         Indent_Incr (File, "is");
+         Indent_Line (File, "pragma Unreferenced (Single_Line_Component);",
+                            "pragma Unreferenced (Named_Association_Component);");
+         Indent_Decr (File, "begin");
       else
          Indent_Line (File, "is begin");
       end if;
@@ -317,34 +285,30 @@ package body Auto_Io_Gen.Generate.Put_Body is
             " Single_Line_Record, Named_Association_Record, Single_Line_Component, Named_Association_Component);");
       end if;
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put;");
+      Indent_Decr (File, "end Put;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Put");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put");
       Indent_Line (File, "(Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Single_Line_Record          : in Boolean := True;",
                          " Named_Association_Record    : in Boolean := False;",
                          " Single_Line_Component       : in Boolean := True;",
                          " Named_Association_Component : in Boolean := False)");
-      Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
-         Indent_Line (File, "is");
-         Indent_Line (File, "   pragma Unreferenced (Single_Line_Component);");
-         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
-         Indent_Line (File, "begin");
+         Indent_Less (File, "is");
+         Indent_Line (File, "pragma Unreferenced (Single_Line_Component);",
+                            "pragma Unreferenced (Named_Association_Component);");
+         Indent_Less (File, "begin");
       else
-         Indent_Line (File, "is begin");
+         Indent_Less (File, "is begin");
       end if;
 
-      Indent_Level := Indent_Level + 1;
       Indent_Line (File, Package_Name & ".Put (Current_Output, Item,");
       case Type_Descriptor.Array_Component_Label is
       when Lists.Scalar_Array_Component_Labels_Type =>
-         Indent_Line (File, " Single_Line => Single_Line_Record,");
-         Indent_Line (File, " Named_Association => Named_Association_Record);");
+         Indent_Line (File, " Single_Line => Single_Line_Record,",
+                            " Named_Association => Named_Association_Record);");
 
       when Lists.Private_Label =>
          Indent_Line
@@ -352,23 +316,17 @@ package body Auto_Io_Gen.Generate.Put_Body is
             " Single_Line_Record, Named_Association_Record, Single_Line_Component, Named_Association_Component);");
       end case;
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put;");
+      Indent_Decr (File, "end Put;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Put_Item");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Put_Item");
       Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
                          " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
                          " Single_Line       : in Boolean := False;",
                          " Named_Association : in Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
       Indent_Line (File, Package_Name & ".Put_Item (File, Item, Single_Line, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put_Item;");
+      Indent_Decr (File, "end Put_Item;");
       New_Line (File);
    end Generate_Private_Array_Wrapper;
 
@@ -424,20 +382,15 @@ package body Auto_Io_Gen.Generate.Put_Body is
                end if;
 
                if not Need_Single_Line_Record then
-                  Indent_Level := Indent_Level + 1;
-                  Indent_Line (File, "pragma Unreferenced (Single_Line_Record);");
-                  Indent_Level := Indent_Level - 1;
+                  Indent_More (File, "pragma Unreferenced (Single_Line_Record);");
                end if;
 
                if not Type_Descriptor.Record_Structured_Components then
-                  Indent_Level := Indent_Level + 1;
-                  Indent_Line (File, "pragma Unreferenced (Named_Association_Component);");
-                  Indent_Level := Indent_Level - 1;
+                  Indent_More (File, "pragma Unreferenced (Named_Association_Component);");
                end if;
             end if;
 
-            Indent_Line (File, "begin");
-            Indent_Level := Indent_Level + 1;
+            Indent_Incr (File, "begin");
          end if;
       end Print_Parameter_List;
 
@@ -524,8 +477,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Print_Components (Type_Descriptor.Record_Components);
          Print_Variant_Part;
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Put_Components;");
+         Indent_Decr (File, "end Put_Components;");
          New_Line (File);
       end if;
 
@@ -540,6 +492,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
             Separate_Body      => True);
 
          Indent_Line (File, "is separate;");
+         New_Line (File);
       end if;
 
       Indent_Line (File, "procedure Put");
@@ -554,7 +507,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
       if Type_Descriptor.Separate_Body then
          Indent_Line (File, "renames " & Separate_Body_Name & ";");
       else
-         Indent_Line (File, "Put (File, String'(""(""));");
+         Indent_Line (File, "Put (File, String' (""(""));");
 
          Body_First := True;
          Print_Components (Type_Descriptor.Record_Discriminants);
@@ -564,23 +517,22 @@ package body Auto_Io_Gen.Generate.Put_Body is
                --  Finish last discriminant put
                Indent_Line
                  (File,
-                  "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
+                  "Put (File, Character' (',')); if not Single_Line_Record then New_Line (File); end if;");
                --  Start components put
-               Indent_Line (File, "Put (File, Character'(' '));");
+               Indent_Line (File, "Put (File, Character' (' '));");
 
             else
                Body_First := False;
             end if;
-            Indent_Line (File, "Put_Components (File, Item, Single_Line_Record, Named_Association_Record,");
-            Indent_Line (File, "     Single_Line_Component, Named_Association_Component);");
+            Indent_Line (File, "Put_Components (File, Item, Single_Line_Record, Named_Association_Record,",
+                               "                Single_Line_Component, Named_Association_Component);");
          else
             Print_Components (Type_Descriptor.Record_Components);
             Print_Variant_Part;
          end if;
 
-         Indent_Line (File, "Put (File, String'("")""));");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Put;");
+         Indent_Line (File, "Put (File, String' ("")""));");
+         Indent_Decr (File, "end Put;");
       end if;
 
       New_Line (File);
@@ -594,10 +546,9 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Discriminants      => True,
          Separate_Body      => False);
 
-      Indent_Line (File, "Put (Current_Output, Item, Single_Line_Record, Named_Association_Record,");
-      Indent_Line (File, "     Single_Line_Component, Named_Association_Component);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put;");
+      Indent_Line (File, "Put (Current_Output, Item, Single_Line_Record, Named_Association_Record,",
+                         "     Single_Line_Component, Named_Association_Component);");
+      Indent_Decr (File, "end Put;");
       New_Line (File);
 
       Indent_Line (File, "procedure Put_Item");
@@ -609,10 +560,9 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Discriminants      => True,
          Separate_Body      => False);
 
-      Indent_Line (File, "Put (File, Item, Single_Line, Named_Association,");
-      Indent_Line (File, "     Single_Line, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Put_Item;");
+      Indent_Line (File, "Put (File, Item, Single_Line, Named_Association,",
+                         "     Single_Line, Named_Association);");
+      Indent_Decr (File, "end Put_Item;");
       New_Line (File);
    end Generate_Record;
 

--- a/src/text_io/auto_io_gen-generate-spec.adb
+++ b/src/text_io/auto_io_gen-generate-spec.adb
@@ -282,9 +282,7 @@ package body Auto_Io_Gen.Generate.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association)");
       else
          Put_Line (File, ")");
       end if;
@@ -348,9 +346,7 @@ package body Auto_Io_Gen.Generate.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association)");
       else
          Put_Line (File, ")");
       end if;
@@ -419,9 +415,7 @@ package body Auto_Io_Gen.Generate.Spec is
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
@@ -440,9 +434,7 @@ package body Auto_Io_Gen.Generate.Spec is
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
@@ -463,13 +455,9 @@ package body Auto_Io_Gen.Generate.Spec is
          Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
                             " Item                      :    out " & Type_Name & ";",
                             " Named_Association_Array   : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 
@@ -477,13 +465,9 @@ package body Auto_Io_Gen.Generate.Spec is
          Indent_Level := Indent_Level + 1;
          Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
                             " Named_Association_Array   : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 

--- a/src/text_io/auto_io_gen-generate.adb
+++ b/src/text_io/auto_io_gen-generate.adb
@@ -374,6 +374,40 @@ package body Auto_Io_Gen.Generate is
       end if;
    end Indent_Line;
 
+   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text  : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level + 1;
+   end Indent_Incr;
+
+   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text  : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, Text);
+   end Indent_Decr;
+
+   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level + 1;
+   end Indent_Less;
+
+   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level - 1;
+   end Indent_More;
+
    function Instantiated_Package_Name (Type_Name : in String) return String
    is
       Root_Name_Index : Natural := Ada.Strings.Fixed.Index (Type_Name, "_Type");

--- a/src/text_io/auto_io_gen-generate.ads
+++ b/src/text_io/auto_io_gen-generate.ads
@@ -67,6 +67,18 @@ private
                           Text9 : in String := "");
    --  Do Set_Indent (File), then Put_Line (File, Text).
 
+   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Call Indent_Line, then increment Indent_Level.
+
+   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Decrement Indent_Level, then call Indent_Line.
+
+   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Decrement Indent_Level, call Indent_Line, increment Indent_Level.
+
+   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Increment Indent_Level, call Indent_Line, decrement Indent_Level.
+
    procedure Instantiate_Generic_Array_Text_IO
      (File            : in Ada.Text_IO.File_Type;
       Type_Descriptor : in Lists.Type_Descriptor_Type);


### PR DESCRIPTION
As a followup to pull request #5, new procedures are added to package [Auto_Io_Gen.Generate](https://github.com/persan/auto-io-gen/blob/master/src/text_io/auto_io_gen-generate.ads):

- procedure `Indent_Incr` calls `Indent_Line`, then increments `Indent_Level`.
- procedure `Indent_Decr` decrements `Indent_Level`, then calls `Indent_Line`.
- procedure `Indent_Less` decrements `Indent_Level`, calls `Indent_Line`, then increments `Indent_Level`.
- procedure `Indent_More` increments `Indent_Level`, calls `Indent_Line`,  then decrements `Indent_Level`.