### PR TITLE
Normalize backend package hierarchy

### DIFF
--- a/src/auto_io_gen-driver.adb
+++ b/src/auto_io_gen-driver.adb
@@ -37,9 +37,9 @@ with Auto_Io_Gen.Build;
 with Auto_Io_Gen.Options;
 with Gnatvsn;
 
-with Auto_Io_Gen.Generate; pragma Warnings (Off, Auto_Io_Gen.Generate);
-with Auto_Io_Gen.Generate_Image; pragma Warnings (Off, Auto_Io_Gen.Generate_Image);
-with Auto_Io_Gen.Generate_JSON; pragma Warnings (Off, Auto_Io_Gen.Generate_JSON);
+with Auto_Io_Gen.Generate.Ada_File; pragma Warnings (Off, Auto_Io_Gen.Generate.Ada_File);
+with Auto_Io_Gen.Generate.Ada_Image; pragma Warnings (Off, Auto_Io_Gen.Generate.Ada_Image);
+with Auto_Io_Gen.Generate.JSON_File; pragma Warnings (Off, Auto_Io_Gen.Generate.JSON_File);
 with A4G.A_Opt;
 procedure Auto_Io_Gen.Driver
 is

--- a/src/auto_io_gen-generate.adb
+++ b/src/auto_io_gen-generate.adb
@@ -1,0 +1,139 @@
+--  Abstract :
+--
+--  see spec.
+--
+--  Copyright (C) 2020 Oliver Kellogg  <okellogg@users.sf.net>
+--
+--  This program is free software; you can redistribute it and/or
+--  modify it under terms of the GNU General Public License as
+--  published by the Free Software Foundation; either version 2, or
+--  (at your option) any later version. This program is distributed in
+--  the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+--  even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+--  PARTICULAR PURPOSE. See the GNU General Public License for more
+--  details. You should have received a copy of the GNU General Public
+--  License distributed with this program; see file COPYING. If not,
+--  write to the Free Software Foundation, 59 Temple Place - Suite
+--  330, Boston, MA 02111-1307, USA.
+
+with Ada.Strings.Fixed;
+with Ada.Strings.Maps;
+with Ada.Directories;
+with Auto_Io_Gen.Options;
+
+package body Auto_Io_Gen.Generate is
+
+   procedure Set_Indent (File : in Ada.Text_IO.File_Type)
+   is
+      use Ada.Text_IO;
+   begin
+      --  Indent 0 means column 1
+      Set_Col (File, 1 + Count (Auto_Io_Gen.Options.Indent) * (Count (Indent_Level) - 1));
+   end Set_Indent;
+
+   procedure Indent (File : in Ada.Text_IO.File_Type; Text : in String)
+   is begin
+      Set_Indent (File);
+      Ada.Text_IO.Put (File, Text);
+   end Indent;
+
+   procedure Indent_Line (File  : in Ada.Text_IO.File_Type;
+                          Text  : in String;
+                          Text1 : in String := "";
+                          Text2 : in String := "";
+                          Text3 : in String := "";
+                          Text4 : in String := "";
+                          Text5 : in String := "";
+                          Text6 : in String := "";
+                          Text7 : in String := "";
+                          Text8 : in String := "";
+                          Text9 : in String := "")
+   is begin
+      Set_Indent (File);
+      Ada.Text_IO.Put_Line (File, Text);
+      if Text1 /= "" then
+         Set_Indent (File);
+         Ada.Text_IO.Put_Line (File, Text1);
+         if Text2 /= "" then
+            Set_Indent (File);
+            Ada.Text_IO.Put_Line (File, Text2);
+            if Text3 /= "" then
+               Set_Indent (File);
+               Ada.Text_IO.Put_Line (File, Text3);
+               if Text4 /= "" then
+                  Set_Indent (File);
+                  Ada.Text_IO.Put_Line (File, Text4);
+                  if Text5 /= "" then
+                     Set_Indent (File);
+                     Ada.Text_IO.Put_Line (File, Text5);
+                     if Text6 /= "" then
+                        Set_Indent (File);
+                        Ada.Text_IO.Put_Line (File, Text6);
+                        if Text7 /= "" then
+                           Set_Indent (File);
+                           Ada.Text_IO.Put_Line (File, Text7);
+                           if Text8 /= "" then
+                              Set_Indent (File);
+                              Ada.Text_IO.Put_Line (File, Text8);
+                              if Text9 /= "" then
+                                 Set_Indent (File);
+                                 Ada.Text_IO.Put_Line (File, Text9);
+                              end if;
+                           end if;
+                        end if;
+                     end if;
+                  end if;
+               end if;
+            end if;
+         end if;
+      end if;
+   end Indent_Line;
+
+   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text  : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level + 1;
+   end Indent_Incr;
+
+   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text  : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, Text);
+   end Indent_Decr;
+
+   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level + 1;
+   end Indent_Less;
+
+   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String)
+   is
+      use type Ada.Text_Io.Count;
+   begin
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, Text);
+      Indent_Level := Indent_Level - 1;
+   end Indent_More;
+
+   function Ada2file (Name : String) return String is
+      Map : constant Ada.Strings.Maps.Character_Mapping :=
+              Ada.Strings.Maps.To_Mapping ("ABCDEFGHIJKLMNOPQRSTUVWXYZ.",
+                                           "abcdefghilklmnopqrstuvwxyz-");
+   begin
+      return Ada.Strings.Fixed.Translate (Name, Mapping => Map);
+   end;
+
+   function Ada2file (Folder, Name , Suffix : String) return String is
+   begin
+      return Ada.Directories.Compose (Folder, Ada2file (Name), Suffix);
+   end;
+
+end Auto_Io_Gen.Generate;

--- a/src/auto_io_gen-generate.ads
+++ b/src/auto_io_gen-generate.ads
@@ -1,0 +1,57 @@
+--  Abstract :
+--
+--  Auto_Io_Gen master child package for code generation.
+--
+--  Copyright (C) 2020 Oliver Kellogg  <okellogg@users.sf.net>
+--
+--  This program is free software; you can redistribute it and/or
+--  modify it under terms of the GNU General Public License as
+--  published by the Free Software Foundation; either version 2, or
+--  (at your option) any later version. This program is distributed in
+--  the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+--  even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+--  PARTICULAR PURPOSE. See the GNU General Public License for more
+--  details. You should have received a copy of the GNU General Public
+--  License distributed with this program; see file COPYING. If not,
+--  write to the Free Software Foundation, 59 Temple Place - Suite
+--  330, Boston, MA 02111-1307, USA.
+
+with Ada.Text_IO;
+
+package Auto_Io_Gen.Generate is
+
+   procedure Set_Indent (File : in Ada.Text_IO.File_Type);
+   Indent_Level : Ada.Text_IO.Positive_Count := 1;
+   --  1 is no indentation.
+
+   procedure Indent (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Do Set_Indent (File), then Put (File, Text).
+
+   procedure Indent_Line (File : in Ada.Text_IO.File_Type;
+                          Text  : in String;
+                          Text1 : in String := "";
+                          Text2 : in String := "";
+                          Text3 : in String := "";
+                          Text4 : in String := "";
+                          Text5 : in String := "";
+                          Text6 : in String := "";
+                          Text7 : in String := "";
+                          Text8 : in String := "";
+                          Text9 : in String := "");
+   --  Do Set_Indent (File), then Put_Line (File, Text).
+
+   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Call Indent_Line, then increment Indent_Level.
+
+   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Decrement Indent_Level, then call Indent_Line.
+
+   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Decrement Indent_Level, call Indent_Line, increment Indent_Level.
+
+   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String);
+   --  Increment Indent_Level, call Indent_Line, decrement Indent_Level.
+
+   function Ada2file (Folder, Name , Suffix : String) return String;
+
+end Auto_Io_Gen.Generate;

--- a/src/auto_io_gen-options.adb
+++ b/src/auto_io_gen-options.adb
@@ -27,6 +27,7 @@ with GNAT.Command_Line;
 with Ada.Directories;
 with Ada.Strings.Unbounded;
 with GNAT.Source_Info;
+with Ada.Text_IO;
 
 package body Auto_Io_Gen.Options is
 

--- a/src/auto_io_gen.adb
+++ b/src/auto_io_gen.adb
@@ -16,6 +16,7 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
+with Ada.Text_IO;
 with Ada.Characters.Handling;
 with Ada.Command_Line;
 with Ada.Exceptions;
@@ -24,8 +25,6 @@ with Asis.Declarations;
 with Asis.Elements;
 with Asis.Expressions;
 with Auto_Io_Gen.Options;
-with Ada.Strings.Fixed;
-with Ada.Strings.Maps;
 with Ada.Directories;
 with GNAT.Traceback.Symbolic;
 package body Auto_Io_Gen is
@@ -219,118 +218,6 @@ package body Auto_Io_Gen is
 
    end Text_IO_Child_Name;
 
-   procedure Set_Indent (File : in Ada.Text_IO.File_Type)
-   is
-      use Ada.Text_IO;
-   begin
-      --  Indent 0 means column 1
-      Set_Col (File, 1 + Count (Auto_Io_Gen.Options.Indent) * (Count (Indent_Level) - 1));
-   end Set_Indent;
-
-   procedure Indent (File : in Ada.Text_IO.File_Type; Text : in String)
-   is begin
-      Set_Indent (File);
-      Ada.Text_IO.Put (File, Text);
-   end Indent;
-
-   procedure Indent_Line (File  : in Ada.Text_IO.File_Type;
-                          Text  : in String;
-                          Text1 : in String := "";
-                          Text2 : in String := "";
-                          Text3 : in String := "";
-                          Text4 : in String := "";
-                          Text5 : in String := "";
-                          Text6 : in String := "";
-                          Text7 : in String := "";
-                          Text8 : in String := "";
-                          Text9 : in String := "")
-   is begin
-      Set_Indent (File);
-      Ada.Text_IO.Put_Line (File, Text);
-      if Text1 /= "" then
-         Set_Indent (File);
-         Ada.Text_IO.Put_Line (File, Text1);
-         if Text2 /= "" then
-            Set_Indent (File);
-            Ada.Text_IO.Put_Line (File, Text2);
-            if Text3 /= "" then
-               Set_Indent (File);
-               Ada.Text_IO.Put_Line (File, Text3);
-               if Text4 /= "" then
-                  Set_Indent (File);
-                  Ada.Text_IO.Put_Line (File, Text4);
-                  if Text5 /= "" then
-                     Set_Indent (File);
-                     Ada.Text_IO.Put_Line (File, Text5);
-                     if Text6 /= "" then
-                        Set_Indent (File);
-                        Ada.Text_IO.Put_Line (File, Text6);
-                        if Text7 /= "" then
-                           Set_Indent (File);
-                           Ada.Text_IO.Put_Line (File, Text7);
-                           if Text8 /= "" then
-                              Set_Indent (File);
-                              Ada.Text_IO.Put_Line (File, Text8);
-                              if Text9 /= "" then
-                                 Set_Indent (File);
-                                 Ada.Text_IO.Put_Line (File, Text9);
-                              end if;
-                           end if;
-                        end if;
-                     end if;
-                  end if;
-               end if;
-            end if;
-         end if;
-      end if;
-   end Indent_Line;
-
-   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text  : in String)
-   is
-      use type Ada.Text_Io.Count;
-   begin
-      Indent_Line (File, Text);
-      Indent_Level := Indent_Level + 1;
-   end Indent_Incr;
-
-   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text  : in String)
-   is
-      use type Ada.Text_Io.Count;
-   begin
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, Text);
-   end Indent_Decr;
-
-   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String)
-   is
-      use type Ada.Text_Io.Count;
-   begin
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, Text);
-      Indent_Level := Indent_Level + 1;
-   end Indent_Less;
-
-   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String)
-   is
-      use type Ada.Text_Io.Count;
-   begin
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, Text);
-      Indent_Level := Indent_Level - 1;
-   end Indent_More;
-
-   function Ada2file (Name : String) return String is
-      Map : constant Ada.Strings.Maps.Character_Mapping :=
-              Ada.Strings.Maps.To_Mapping ("ABCDEFGHIJKLMNOPQRSTUVWXYZ.",
-                                           "abcdefghilklmnopqrstuvwxyz-");
-   begin
-      return Ada.Strings.Fixed.Translate (Name, Mapping => Map);
-   end;
-
-   function Ada2file (Folder, Name , Suffix : String) return String is
-   begin
-      return Ada.Directories.Compose (Folder, Ada2file (Name), Suffix);
-   end;
    procedure Traceback is
    begin
       if Auto_Io_Gen.Options.Debug then

--- a/src/auto_io_gen.ads
+++ b/src/auto_io_gen.ads
@@ -28,7 +28,7 @@
 --  330, Boston, MA 02111-1307, USA.
 
 with Asis;
-with Ada.Text_IO;
+
 package Auto_Io_Gen is
 --   pragma Elaborate_Body; --  Asis is, but this is circular with Options.
 
@@ -68,38 +68,5 @@ package Auto_Io_Gen is
    Not_Implemented : exception;
    Not_Found       : exception;
 
-   procedure Set_Indent (File : in Ada.Text_IO.File_Type);
-   Indent_Level : Ada.Text_IO.Positive_Count := 1;
-   --  1 is no indentation.
-
-   procedure Indent (File : in Ada.Text_IO.File_Type; Text : in String);
-   --  Do Set_Indent (File), then Put (File, Text).
-
-   procedure Indent_Line (File : in Ada.Text_IO.File_Type;
-                          Text  : in String;
-                          Text1 : in String := "";
-                          Text2 : in String := "";
-                          Text3 : in String := "";
-                          Text4 : in String := "";
-                          Text5 : in String := "";
-                          Text6 : in String := "";
-                          Text7 : in String := "";
-                          Text8 : in String := "";
-                          Text9 : in String := "");
-   --  Do Set_Indent (File), then Put_Line (File, Text).
-
-   procedure Indent_Incr (File : in Ada.Text_IO.File_Type; Text : in String);
-   --  Call Indent_Line, then increment Indent_Level.
-
-   procedure Indent_Decr (File : in Ada.Text_IO.File_Type; Text : in String);
-   --  Decrement Indent_Level, then call Indent_Line.
-
-   procedure Indent_Less (File : in Ada.Text_IO.File_Type; Text : in String);
-   --  Decrement Indent_Level, call Indent_Line, increment Indent_Level.
-
-   procedure Indent_More (File : in Ada.Text_IO.File_Type; Text : in String);
-   --  Increment Indent_Level, call Indent_Line, decrement Indent_Level.
-
-   function Ada2file (Folder, Name , Suffix : String) return String;
    procedure Traceback;
 end Auto_Io_Gen;

--- a/src/image/auto_io_gen-generate-ada_image-put_body.adb
+++ b/src/image/auto_io_gen-generate-ada_image-put_body.adb
@@ -20,31 +20,32 @@ with Asis.Aux;
 with Asis.Elements;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate_JSON.Put_Body is
+package body Auto_Io_Gen.Generate.Ada_Image.Put_Body is
    use Ada.Text_IO;
 
    Body_First : Boolean := True; --  Shared between printing discriminants and components.
 
    procedure Generate_Component_Line
-      (File      : in Ada.Text_IO.File_Type;
-       Component : in Auto_Io_Gen.Lists.Component_Type;
-       First     : in Boolean);
+     (File      : in Ada.Text_IO.File_Type;
+      Component : in Auto_Io_Gen.Lists.Component_Type;
+      First     : in Boolean);
    --  Generate body code to put one component.
 
    procedure Generate_Derived_Array
-      (File            : in Ada.Text_IO.File_Type;
-       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
+
    --  Generate body code for all Put subprograms for a derived array type.
 
    procedure Generate_Private_Array_Wrapper
-      (File            : in Ada.Text_IO.File_Type;
-       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
    --  Generate body code for all Put subprograms in the public child
    --  for a private array type.
 
    procedure Generate_Record
-      (File            : in Ada.Text_IO.File_Type;
-       Type_Descriptor : in Auto_Io_Gen.Lists.Record_Type_Descriptor_Type);
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Record_Type_Descriptor_Type);
    --  Generate body code for all Put subprograms for a record type.
 
    procedure Generate
@@ -88,9 +89,9 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
    end Generate;
 
    procedure Generate_Component_Line
-      (File      : in Ada.Text_IO.File_Type;
-       Component : in Auto_Io_Gen.Lists.Component_Type;
-       First     : in Boolean)
+     (File      : in Ada.Text_IO.File_Type;
+      Component : in Auto_Io_Gen.Lists.Component_Type;
+      First     : in Boolean)
    is
       pragma Unreferenced (First);
       Component_Name : constant String := Asis.Aux.Name (Component.Component_Name);
@@ -99,11 +100,11 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
       if not Body_First then
          --  Finish last component put
          Indent_Line
-            (File,
-             "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
+           (File,
+            "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
 
          --  Start current component put
-         Indent (File, "Put (File, ' ');");
+         Indent (File, "Put (File, Character'(' '));");
 
       else
          Body_First := False;
@@ -131,21 +132,20 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
          Indent_Level := Indent_Level + 1;
 
          Indent_Line
-            (File,
-             "Single_Line => Single_Line_Component, Named_Association => Named_Association_Component);");
+           (File,
+            "Single_Line => Single_Line_Component, Named_Association => Named_Association_Component);");
          Indent_Level := Indent_Level - 1;
       end if;
 
    end Generate_Component_Line;
 
    procedure Generate_Derived_Array
-      (File            : in Ada.Text_IO.File_Type;
-       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
    is begin
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
       Indent_Line (File, " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";");
       Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
       Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
@@ -204,7 +204,6 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
 
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
       Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
       Indent_Line (File, " Single_Line       : in Boolean := False;");
       Indent_Line (File, " Named_Association : in Boolean := False)");
@@ -219,8 +218,8 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
    end Generate_Derived_Array;
 
    procedure Generate_Private_Array_Wrapper
-      (File            : in Ada.Text_IO.File_Type;
-       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
    is
       Package_Name : constant String := Instantiated_Package_Name (Asis.Aux.Name (Type_Descriptor.Type_Name));
    begin
@@ -287,7 +286,6 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
       Indent_Line (File, " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
       Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
       Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
@@ -358,7 +356,6 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
 
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
       Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
       Indent_Line (File, " Single_Line       : in Boolean := False;");
       Indent_Line (File, " Named_Association : in Boolean := False)");
@@ -385,65 +382,22 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
          Discriminants      : in Boolean;
          Separate_Body      : in Boolean)
       is
-         Need_Single_Line_Record : Boolean;
+         pragma Unreferenced (Is_Item, With_File, Check_Unreferenced, Separate_Body, Discriminants);
       begin
          Indent_Level := Indent_Level + 1;
-         if With_File then
-            Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-            Indent (File, " ");
-         else
-            Indent (File, "(");
-         end if;
 
-         Put_Line (File, "Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
+         Put_Line (File, "Item : in " & Lists.Type_Name (Type_Descriptor) & ";");
 
-         if Is_Item then
-            Indent_Line (File, " Single_Line                 : in Boolean := False;");
-            Indent_Line (File, " Named_Association           : in Boolean := False)");
-         else
-            Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-            Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-            Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-            Indent_Line (File, " Named_Association_Component : in Boolean := False)");
-         end if;
 
          Indent_Level := Indent_Level - 1;
 
-         if not Separate_Body then
-            Indent_Line (File, "is");
-
-            if Check_Unreferenced then
-               if Discriminants then
-                  Need_Single_Line_Record :=
-                    Lists.Length (Type_Descriptor.Record_Components) +
-                    Lists.Length (Type_Descriptor.Record_Discriminants) +
-                    Lists.Length (Type_Descriptor.Record_Variant_Part.Variants) > 1;
-               else
-                  Need_Single_Line_Record :=
-                    Lists.Length (Type_Descriptor.Record_Components) > 1;
-               end if;
-
-               if not Need_Single_Line_Record then
-                  Indent_Level := Indent_Level + 1;
-                  Indent_Line (File, "pragma Unreferenced (Single_Line_Record);");
-                  Indent_Level := Indent_Level - 1;
-               end if;
-
-               if not Type_Descriptor.Record_Structured_Components then
-                  Indent_Level := Indent_Level + 1;
-                  Indent_Line (File, "pragma Unreferenced (Named_Association_Component);");
-                  Indent_Level := Indent_Level - 1;
-               end if;
-            end if;
-
-            Indent_Line (File, "begin");
-            Indent_Level := Indent_Level + 1;
-         end if;
+         Indent_Line (File, "begin");
+         Indent_Level := Indent_Level + 1;
       end Print_Parameter_List;
 
       procedure Print_Component
-         (Component : in Lists.Component_Type;
-          First     : in Boolean)
+        (Component : in Lists.Component_Type;
+         First     : in Boolean)
       is
          pragma Unreferenced (First);
       begin
@@ -453,7 +407,7 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
       procedure Print_Components is new Lists.Component_Algs.Process_All_Constant (Process_Item => Print_Component);
 
       procedure Print_Variant
-        (Variant : in Lists.Variant_Access_Type;
+        (Variant   : in Lists.Variant_Access_Type;
          First     : in Boolean)
       is
          pragma Unreferenced (First);
@@ -616,4 +570,4 @@ package body Auto_Io_Gen.Generate_JSON.Put_Body is
       New_Line (File);
    end Generate_Record;
 
-end Auto_Io_Gen.Generate_JSON.Put_Body;
+end Auto_Io_Gen.Generate.Ada_Image.Put_Body;

--- a/src/image/auto_io_gen-generate-ada_image-put_body.ads
+++ b/src/image/auto_io_gen-generate-ada_image-put_body.ads
@@ -1,6 +1,6 @@
 --  Abstract :
 --
---  Generate Get procedure body for one type.
+--  Generate Put procedure body for one type.
 --
 --  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
 --
@@ -18,12 +18,12 @@
 
 with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate_JSON.Get_Body is
+private package Auto_Io_Gen.Generate.Ada_Image.Put_Body is
    pragma Elaborate_Body; --  Ada.Text_IO, Asis
 
    procedure Generate
      (File            : in Ada.Text_IO.File_Type;
       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
-   --  Generate body code for a Get procedure for one type.
+   --  Generate body code for a Put procedure for one type.
 
-end Auto_Io_Gen.Generate_JSON.Get_Body;
+end Auto_Io_Gen.Generate.Ada_Image.Put_Body;

--- a/src/image/auto_io_gen-generate-ada_image-spec.adb
+++ b/src/image/auto_io_gen-generate-ada_image-spec.adb
@@ -21,7 +21,7 @@ with Asis.Aux;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
 with GNAT.Source_Info;
-package body Auto_Io_Gen.Generate_Image.Spec is
+package body Auto_Io_Gen.Generate.Ada_Image.Spec is
    use  GNAT.Source_Info;
    procedure Generate_Put_Get_Array_Spec
      (File            : in Ada.Text_IO.File_Type;
@@ -341,7 +341,7 @@ package body Auto_Io_Gen.Generate_Image.Spec is
 
       Indent_Line (File, "function I_Image (  Item : in " & Type_Name & ") return String;");
       if Type_Descriptor.Record_Tagged then
-         Indent_Line (File, "function I__Image_Components (  Item : in " & Type_Name & ") return String;");
+         Indent_Line (File, "function I_Image_Components (  Item : in " & Type_Name & ") return String;");
       end if;
 
       New_Line (File);
@@ -383,4 +383,4 @@ package body Auto_Io_Gen.Generate_Image.Spec is
       Indent_Line (File, "function Image (  Item : " & Type_Name & ") return String is (Item'Img);");
    end Generate_Put_Get_Scalar_Spec;
 
-end Auto_Io_Gen.Generate_Image.Spec;
+end Auto_Io_Gen.Generate.Ada_Image.Spec;

--- a/src/image/auto_io_gen-generate-ada_image-spec.ads
+++ b/src/image/auto_io_gen-generate-ada_image-spec.ads
@@ -17,7 +17,7 @@
 --  330, Boston, MA 02111-1307, USA.
 
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate.Spec is
+private package Auto_Io_Gen.Generate.Ada_Image.Spec is
    pragma Elaborate_Body;  --  Ada.Text_IO, Asis
 
    procedure Generate_Child_Spec
@@ -31,4 +31,4 @@ private package Auto_Io_Gen.Generate.Spec is
       Is_Generic          : in Boolean);
    --  Generate child package spec. File must be open for write.
 
-end Auto_Io_Gen.Generate.Spec;
+end Auto_Io_Gen.Generate.Ada_Image.Spec;

--- a/src/image/auto_io_gen-generate-ada_image.adb
+++ b/src/image/auto_io_gen-generate-ada_image.adb
@@ -63,12 +63,12 @@ with Ada.IO_Exceptions;
 with Ada.Strings.Fixed;
 with Asis.Aux;
 with Asis.Elements;
-with Auto_Io_Gen.Generate_Image.Put_Body;
-with Auto_Io_Gen.Generate_Image.Spec;
+with Auto_Io_Gen.Generate.Ada_Image.Put_Body;
+with Auto_Io_Gen.Generate.Ada_Image.Spec;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
 with GNAT.Source_Info;
-package body Auto_Io_Gen.Generate_Image is
+package body Auto_Io_Gen.Generate.Ada_Image is
    use GNAT.Source_Info;
    --------------
    --  Local declarations
@@ -436,4 +436,4 @@ begin
       Generator => Create_Text_IO_Child'Access,
       Std_Names =>  Standard_Name'Access);
 
-end Auto_Io_Gen.Generate_Image;
+end Auto_Io_Gen.Generate.Ada_Image;

--- a/src/image/auto_io_gen-generate-ada_image.ads
+++ b/src/image/auto_io_gen-generate-ada_image.ads
@@ -16,8 +16,9 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
+with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-package Auto_Io_Gen.Generate_JSON is
+package Auto_Io_Gen.Generate.Ada_Image is
 --   pragma Elaborate_Body; -- Body depends on Text_IO, but this is circular due to child packages.
 
    procedure Create_Text_IO_Child
@@ -36,10 +37,6 @@ private
 
    --  Visible for child packages.
 
-
-   function Ada_Text_IO return String;
-   --  Return "Ada.Text_IO".
-   --  TBC: Ada_83 mode was removed - candidate for removal.
 
    function Component_Type_Name
       (Type_Element         : in Asis.Element;
@@ -63,4 +60,5 @@ private
    function Root_Type_Name (Type_Name : in String) return String;
    --  Return Type_Name without trailing _Type, if any.
 
-end Auto_Io_Gen.Generate_JSON;
+
+end Auto_Io_Gen.Generate.Ada_Image;

--- a/src/json/auto_io_gen-generate-json_file-get_body.adb
+++ b/src/json/auto_io_gen-generate-json_file-get_body.adb
@@ -22,7 +22,7 @@ with Asis.Declarations;
 with Asis.Elements;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate.Get_Body is
+package body Auto_Io_Gen.Generate.JSON_File.Get_Body is
    use Ada.Text_IO;
 
    Body_First : Boolean := True; -- Shared between printing discriminants and components.
@@ -141,7 +141,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Indent_Line (File, "Get (File, Temp_Item." & Component_Name & ");");
       else
          Indent_Line (File, "Get_Item (File, Temp_Item." & Component_Name & ",");
-         Indent_More (File, "Named_Association => Named_Association_Component);");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "Named_Association => Named_Association_Component);");
+         Indent_Level := Indent_Level - 1;
       end if;
 
    end Generate_Component_Temp_Get;
@@ -153,12 +155,14 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association_Array   : in     Boolean := False;",
-                         " Named_Association_Element : in     Boolean := False)");
+      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
+      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
 
-      Indent_Less (File, "is begin");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
 
       if Asis.Elements.Is_Nil (Type_Descriptor.Derived_Root_Package_Declaration) then
          Indent_Line (File, "Get");
@@ -191,22 +195,32 @@ package body Auto_Io_Gen.Generate.Get_Body is
       Indent_Line (File, "end Get;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Get");
-      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association_Array   : in     Boolean := False;",
-                         " Named_Association_Element : in     Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
+      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Array, Named_Association_Element);");
-      Indent_Decr (File, "end Get;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Get_Item");
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association : in     Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Get_Item");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Decr (File, "end Get_Item;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get_Item;");
       New_Line (File);
    end Generate_Derived_Array;
 
@@ -279,7 +293,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
               Discriminant_Name &
               ") then");
       end if;
-      Indent_More (File, "raise Discriminant_Error;");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "raise Discriminant_Error;");
+      Indent_Level := Indent_Level - 1;
       Indent_Line (File, "end if;");
 
    end Generate_Discriminant_Compare;
@@ -292,12 +308,13 @@ package body Auto_Io_Gen.Generate.Get_Body is
    begin
       --  Generic_Array_IO was instantiated by Put_Body.
 
-      Indent_Incr (File, "procedure Get");
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
-                         " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
 
@@ -320,19 +337,20 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
 
-      Indent_Decr (File, "end Get;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
          Indent_Line (File, "is");
-         Indent_More (File, "pragma Unreferenced (Named_Association_Component);");
+         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
          Indent_Line (File, "begin");
       else
          Indent_Line (File, "is begin");
@@ -345,17 +363,22 @@ package body Auto_Io_Gen.Generate.Get_Body is
       else
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
-      Indent_Decr (File, "end Get;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association : in     Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, Package_Name & ".Get_Item (File, Item, Named_Association);");
-      Indent_Decr (File, "end Get_Item;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get_Item;");
       New_Line (File);
    end Generate_Private_Array_Wrapper;
 
@@ -369,10 +392,10 @@ package body Auto_Io_Gen.Generate.Get_Body is
       is begin
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
-                            " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                            " Named_Association_Record    : in     Boolean := False;",
-                            " Named_Association_Component : in     Boolean := False)");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
 
          Indent_Level := Indent_Level - 1;
       end Print_Parameter_List;
@@ -504,7 +527,9 @@ package body Auto_Io_Gen.Generate.Get_Body is
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
          end if;
 
-         Indent_Less (File, "begin");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "begin");
+         Indent_Level := Indent_Level + 1;
 
          Body_First := True;
 
@@ -517,14 +542,17 @@ package body Auto_Io_Gen.Generate.Get_Body is
          if Type_Descriptor.Record_Constrained then
             Print_Discriminant_Compares (Type_Descriptor.Record_Discriminants);
          else
-            Indent_Incr (File, "declare");
+            Indent_Line (File, "declare");
+            Indent_Level := Indent_Level + 1;
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name));
             Indent_Level := Indent_Level + 1;
             Indent (File, "(");
             Print_Discriminants (Type_Descriptor.Record_Discriminants);
             Put_Line (File, ");");
             Indent_Level := Indent_Level - 1;
-            Indent_Less (File, "begin");
+            Indent_Level := Indent_Level - 1;
+            Indent_Line (File, "begin");
+            Indent_Level := Indent_Level + 1;
          end if;
 
          if Type_Descriptor.Record_Derived then
@@ -540,16 +568,16 @@ package body Auto_Io_Gen.Generate.Get_Body is
               (File,
                Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  ".Text_IO.Get_Components");
-            Indent_Level := Indent_Level + 1;
             Indent_Line
               (File,
                " (File, " &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  "." &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Type_Name) &
-                 " (Temp_Item),",
+                 " (Temp_Item),");
+            Indent_Line
+              (File,
                "Named_Association_Record, Named_Association_Component);");
-            Indent_Level := Indent_Level - 1;
          end if;
 
          if Type_Descriptor.Record_Tagged then
@@ -570,31 +598,43 @@ package body Auto_Io_Gen.Generate.Get_Body is
 
          if not Type_Descriptor.Record_Constrained then
             Indent_Line (File, "Item := Temp_Item;");
-            Indent_Decr (File, "end;");
+            Indent_Level := Indent_Level - 1;
+            Indent_Line (File, "end;");
          end if;
 
          Indent_Line (File, "Check (File, "")"");");
-         Indent_Decr (File, "end Get;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Get;");
          New_Line (File);
 
       end if;
 
-      Indent_Incr (File, "procedure Get");
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Record, Named_Association_Component);");
-      Indent_Decr (File, "end Get;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Get_Item");
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Named_Association : in     Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Get_Item");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Named_Association : in     Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Decr (File, "end Get_Item;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Get_Item;");
       New_Line (File);
 
       if Type_Descriptor.Record_Tagged then
@@ -602,17 +642,20 @@ package body Auto_Io_Gen.Generate.Get_Body is
          Print_Parameter_List;
 
          Indent_Line (File, "is");
-         Indent_More (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
+         Indent_Level := Indent_Level - 1;
          Indent_Line (File, "begin");
          Indent_Level := Indent_Level + 1;
 
          Body_First := True;
          Print_Component_Gets (Type_Descriptor.Record_Components);
 
-         Indent_Decr (File, "end Get_Components;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Get_Components;");
          New_Line (File);
       end if;
 
    end Generate_Record;
 
-end Auto_Io_Gen.Generate.Get_Body;
+end Auto_Io_Gen.Generate.JSON_File.Get_Body;

--- a/src/json/auto_io_gen-generate-json_file-get_body.ads
+++ b/src/json/auto_io_gen-generate-json_file-get_body.ads
@@ -1,8 +1,8 @@
 --  Abstract :
 --
---  Generate child package spec.
+--  Generate Get procedure body for one type.
 --
---  Copyright (C) 2001 - 2004 Stephen Leake.  All Rights Reserved.
+--  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
 --
 --  This program is free software; you can redistribute it and/or
 --  modify it under terms of the GNU General Public License as
@@ -16,19 +16,14 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
+with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate_JSON.Spec is
-   pragma Elaborate_Body;  --  Ada.Text_IO, Asis
+private package Auto_Io_Gen.Generate.JSON_File.Get_Body is
+   pragma Elaborate_Body; --  Ada.Text_IO, Asis
 
-   procedure Generate_Child_Spec
-     (File                : in Ada.Text_IO.File_Type;
-      Type_List           : in Lists.Type_Descriptor_Lists.List_Type;
-      With_List           : in Lists.Context_Trees.Tree_Type;
-      Formal_Package_List : in Lists.Formal_Package_Lists.List_Type;
-      Parent_Package_Name : in String;
-      Child_Package_Name  : in String;
-      Invisible           : in Boolean;
-      Is_Generic          : in Boolean);
-   --  Generate child package spec. File must be open for write.
+   procedure Generate
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
+   --  Generate body code for a Get procedure for one type.
 
-end Auto_Io_Gen.Generate_JSON.Spec;
+end Auto_Io_Gen.Generate.JSON_File.Get_Body;

--- a/src/json/auto_io_gen-generate-json_file-put_body.adb
+++ b/src/json/auto_io_gen-generate-json_file-put_body.adb
@@ -20,7 +20,7 @@ with Asis.Aux;
 with Asis.Elements;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate.Put_Body is
+package body Auto_Io_Gen.Generate.JSON_File.Put_Body is
    use Ada.Text_IO;
 
    Body_First : Boolean := True; --  Shared between printing discriminants and components.
@@ -100,19 +100,19 @@ package body Auto_Io_Gen.Generate.Put_Body is
          --  Finish last component put
          Indent_Line
             (File,
-             "Put (File, Character' (',')); if not Single_Line_Record then New_Line (File); end if;");
+             "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
 
          --  Start current component put
-         Indent (File, "Put (File, Character' (' '));");
+         Indent (File, "Put (File, ' ');");
 
       else
          Body_First := False;
       end if;
 
-      Indent_Line (File, "if Named_Association_Record then",
-                         "   Put (File, """ & Component_Name & " => "");",
-                         "   if not Single_Line_Component then New_Line (File); end if;",
-                         "end if;");
+      Indent_Line (File, "if Named_Association_Record then");
+      Indent_Line (File, "   Put (File, """ & Component_Name & " => "");");
+      Indent_Line (File, "   if not Single_Line_Component then New_Line (File); end if;");
+      Indent_Line (File, "end if;");
 
       if Asis.Elements.Is_Nil (Component.Type_Package) then
          if Component.Invisible then
@@ -128,9 +128,12 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Put_Line (File, "Put (File, Item." & Component_Name & ");");
       else
          Put_Line (File, "Put_Item (File, Item." & Component_Name & ",");
-         Indent_More
+         Indent_Level := Indent_Level + 1;
+
+         Indent_Line
             (File,
              "Single_Line => Single_Line_Component, Named_Association => Named_Association_Component);");
+         Indent_Level := Indent_Level - 1;
       end if;
 
    end Generate_Component_Line;
@@ -139,16 +142,19 @@ package body Auto_Io_Gen.Generate.Put_Body is
       (File            : in Ada.Text_IO.File_Type;
        Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type)
    is begin
-      Indent_Incr (File, "procedure Put");
+      Indent_Line (File, "procedure Put");
+      Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
-                         " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line_Array         : in Boolean := False;",
-                         " Named_Association_Array   : in Boolean := False;",
-                         " Single_Line_Element       : in Boolean := True;",
-                         " Named_Association_Element : in Boolean := False)");
+      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
+      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Element : in Boolean := False)");
 
-      Indent_Less (File, "is begin");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
 
       if Asis.Elements.Is_Nil (Type_Descriptor.Derived_Root_Package_Declaration) then
          Indent (File, "Put");
@@ -174,30 +180,41 @@ package body Auto_Io_Gen.Generate.Put_Body is
 
       Indent_Line
         (File, " Single_Line_Array, Named_Association_Array, Single_Line_Element, Named_Association_Element);");
-      Indent_Decr (File, "end Put;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Put");
-      Indent_Line (File, "(Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line_Array         : in Boolean := False;",
-                         " Named_Association_Array   : in Boolean := False;",
-                         " Single_Line_Element       : in Boolean := True;",
-                         " Named_Association_Element : in Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Put");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                      : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
+      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Element : in Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Put (Current_Output, Item,");
       Indent_Line
         (File, "     Single_Line_Array, Named_Association_Array, Single_Line_Element, Named_Association_Element);");
-      Indent_Decr (File, "end Put;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Put_Item");
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                         " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line       : in Boolean := False;",
-                         " Named_Association : in Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Put_Item");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line       : in Boolean := False;");
+      Indent_Line (File, " Named_Association : in Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, "Put (File, Item, Single_Line, Named_Association, Single_Line, Named_Association);");
-      Indent_Decr (File, "end Put_Item;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put_Item;");
       New_Line (File);
    end Generate_Derived_Array;
 
@@ -214,61 +231,76 @@ package body Auto_Io_Gen.Generate.Put_Body is
          null;
 
       when Lists.Enumeration_Label =>
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Width (Width : in Ada.Text_IO.Field)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Width (Width : in Ada.Text_IO.Field)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Width := Width;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Width;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Width;");
 
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Setting (Setting : in Ada.Text_IO.Type_Set)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Setting (Setting : in Ada.Text_IO.Type_Set)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Setting := Setting;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Setting;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Setting;");
 
       when Lists.Float_Label =>
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Fore (Fore : in Ada.Text_IO.Field)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Fore (Fore : in Ada.Text_IO.Field)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Fore := Fore;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Fore;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Fore;");
 
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Aft (Aft : in Ada.Text_IO.Field)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Aft (Aft : in Ada.Text_IO.Field)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Aft := Aft;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Aft;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Aft;");
 
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Exp (Exp : in Ada.Text_IO.Field)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Exp (Exp : in Ada.Text_IO.Field)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Exp := Exp;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Exp;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Exp;");
 
       when Lists.Signed_Integer_Label | Lists.Modular_Integer_Label =>
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Width (Width : Ada.Text_IO.Field)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Width (Width : Ada.Text_IO.Field)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Width := Width;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Width;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Width;");
 
-         Indent_Incr (File, "procedure Set_" & Package_Name & "_Default_Base (Base : Ada.Text_IO.Number_Base)");
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "procedure Set_" & Package_Name & "_Default_Base (Base : Ada.Text_IO.Number_Base)");
+         Indent_Line (File, "is begin");
+         Indent_Level := Indent_Level + 1;
          Indent_Line (File, Package_Name & ".Default_Base := Base;");
-         Indent_Decr (File, "end Set_" & Package_Name & "_Default_Base;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Set_" & Package_Name & "_Default_Base;");
 
       end case;
 
-      Indent_Incr (File, "procedure Put");
+      Indent_Line (File, "procedure Put");
+      Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
-                         " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False)");
+      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
-         Indent_Incr (File, "is");
-         Indent_Line (File, "pragma Unreferenced (Single_Line_Component);",
-                            "pragma Unreferenced (Named_Association_Component);");
-         Indent_Decr (File, "begin");
+         Indent_Line (File, "is");
+         Indent_Line (File, "   pragma Unreferenced (Single_Line_Component);");
+         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
+         Indent_Line (File, "begin");
       else
          Indent_Line (File, "is begin");
       end if;
@@ -285,30 +317,34 @@ package body Auto_Io_Gen.Generate.Put_Body is
             " Single_Line_Record, Named_Association_Record, Single_Line_Component, Named_Association_Component);");
       end if;
 
-      Indent_Decr (File, "end Put;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Put");
-      Indent_Line (File, "(Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False)");
+      Indent_Line (File, "procedure Put");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False)");
+      Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
-         Indent_Less (File, "is");
-         Indent_Line (File, "pragma Unreferenced (Single_Line_Component);",
-                            "pragma Unreferenced (Named_Association_Component);");
-         Indent_Less (File, "begin");
+         Indent_Line (File, "is");
+         Indent_Line (File, "   pragma Unreferenced (Single_Line_Component);");
+         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
+         Indent_Line (File, "begin");
       else
-         Indent_Less (File, "is begin");
+         Indent_Line (File, "is begin");
       end if;
 
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, Package_Name & ".Put (Current_Output, Item,");
       case Type_Descriptor.Array_Component_Label is
       when Lists.Scalar_Array_Component_Labels_Type =>
-         Indent_Line (File, " Single_Line => Single_Line_Record,",
-                            " Named_Association => Named_Association_Record);");
+         Indent_Line (File, " Single_Line => Single_Line_Record,");
+         Indent_Line (File, " Named_Association => Named_Association_Record);");
 
       when Lists.Private_Label =>
          Indent_Line
@@ -316,17 +352,23 @@ package body Auto_Io_Gen.Generate.Put_Body is
             " Single_Line_Record, Named_Association_Record, Single_Line_Component, Named_Association_Component);");
       end case;
 
-      Indent_Decr (File, "end Put;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put;");
       New_Line (File);
 
-      Indent_Incr (File, "procedure Put_Item");
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                         " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";",
-                         " Single_Line       : in Boolean := False;",
-                         " Named_Association : in Boolean := False)");
-      Indent_Less (File, "is begin");
+      Indent_Line (File, "procedure Put_Item");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              : in " & Lists.Type_Name (Type_Descriptor) & ";");
+      Indent_Line (File, " Single_Line       : in Boolean := False;");
+      Indent_Line (File, " Named_Association : in Boolean := False)");
+      Indent_Level := Indent_Level - 1;
+
+      Indent_Line (File, "is begin");
+      Indent_Level := Indent_Level + 1;
       Indent_Line (File, Package_Name & ".Put_Item (File, Item, Single_Line, Named_Association);");
-      Indent_Decr (File, "end Put_Item;");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put_Item;");
       New_Line (File);
    end Generate_Private_Array_Wrapper;
 
@@ -356,13 +398,13 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Put_Line (File, "Item                        : in " & Lists.Type_Name (Type_Descriptor) & ";");
 
          if Is_Item then
-            Indent_Line (File, " Single_Line                 : in Boolean := False;",
-                               " Named_Association           : in Boolean := False)");
+            Indent_Line (File, " Single_Line                 : in Boolean := False;");
+            Indent_Line (File, " Named_Association           : in Boolean := False)");
          else
-            Indent_Line (File, " Single_Line_Record          : in Boolean := True;",
-                               " Named_Association_Record    : in Boolean := False;",
-                               " Single_Line_Component       : in Boolean := True;",
-                               " Named_Association_Component : in Boolean := False)");
+            Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+            Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+            Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+            Indent_Line (File, " Named_Association_Component : in Boolean := False)");
          end if;
 
          Indent_Level := Indent_Level - 1;
@@ -382,15 +424,20 @@ package body Auto_Io_Gen.Generate.Put_Body is
                end if;
 
                if not Need_Single_Line_Record then
-                  Indent_More (File, "pragma Unreferenced (Single_Line_Record);");
+                  Indent_Level := Indent_Level + 1;
+                  Indent_Line (File, "pragma Unreferenced (Single_Line_Record);");
+                  Indent_Level := Indent_Level - 1;
                end if;
 
                if not Type_Descriptor.Record_Structured_Components then
-                  Indent_More (File, "pragma Unreferenced (Named_Association_Component);");
+                  Indent_Level := Indent_Level + 1;
+                  Indent_Line (File, "pragma Unreferenced (Named_Association_Component);");
+                  Indent_Level := Indent_Level - 1;
                end if;
             end if;
 
-            Indent_Incr (File, "begin");
+            Indent_Line (File, "begin");
+            Indent_Level := Indent_Level + 1;
          end if;
       end Print_Parameter_List;
 
@@ -477,7 +524,8 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Print_Components (Type_Descriptor.Record_Components);
          Print_Variant_Part;
 
-         Indent_Decr (File, "end Put_Components;");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Put_Components;");
          New_Line (File);
       end if;
 
@@ -492,7 +540,6 @@ package body Auto_Io_Gen.Generate.Put_Body is
             Separate_Body      => True);
 
          Indent_Line (File, "is separate;");
-         New_Line (File);
       end if;
 
       Indent_Line (File, "procedure Put");
@@ -507,7 +554,7 @@ package body Auto_Io_Gen.Generate.Put_Body is
       if Type_Descriptor.Separate_Body then
          Indent_Line (File, "renames " & Separate_Body_Name & ";");
       else
-         Indent_Line (File, "Put (File, String' (""(""));");
+         Indent_Line (File, "Put (File, String'(""(""));");
 
          Body_First := True;
          Print_Components (Type_Descriptor.Record_Discriminants);
@@ -517,22 +564,23 @@ package body Auto_Io_Gen.Generate.Put_Body is
                --  Finish last discriminant put
                Indent_Line
                  (File,
-                  "Put (File, Character' (',')); if not Single_Line_Record then New_Line (File); end if;");
+                  "Put (File, Character'(',')); if not Single_Line_Record then New_Line (File); end if;");
                --  Start components put
-               Indent_Line (File, "Put (File, Character' (' '));");
+               Indent_Line (File, "Put (File, Character'(' '));");
 
             else
                Body_First := False;
             end if;
-            Indent_Line (File, "Put_Components (File, Item, Single_Line_Record, Named_Association_Record,",
-                               "                Single_Line_Component, Named_Association_Component);");
+            Indent_Line (File, "Put_Components (File, Item, Single_Line_Record, Named_Association_Record,");
+            Indent_Line (File, "     Single_Line_Component, Named_Association_Component);");
          else
             Print_Components (Type_Descriptor.Record_Components);
             Print_Variant_Part;
          end if;
 
-         Indent_Line (File, "Put (File, String' ("")""));");
-         Indent_Decr (File, "end Put;");
+         Indent_Line (File, "Put (File, String'("")""));");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "end Put;");
       end if;
 
       New_Line (File);
@@ -546,9 +594,10 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Discriminants      => True,
          Separate_Body      => False);
 
-      Indent_Line (File, "Put (Current_Output, Item, Single_Line_Record, Named_Association_Record,",
-                         "     Single_Line_Component, Named_Association_Component);");
-      Indent_Decr (File, "end Put;");
+      Indent_Line (File, "Put (Current_Output, Item, Single_Line_Record, Named_Association_Record,");
+      Indent_Line (File, "     Single_Line_Component, Named_Association_Component);");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put;");
       New_Line (File);
 
       Indent_Line (File, "procedure Put_Item");
@@ -560,10 +609,11 @@ package body Auto_Io_Gen.Generate.Put_Body is
          Discriminants      => True,
          Separate_Body      => False);
 
-      Indent_Line (File, "Put (File, Item, Single_Line, Named_Association,",
-                         "     Single_Line, Named_Association);");
-      Indent_Decr (File, "end Put_Item;");
+      Indent_Line (File, "Put (File, Item, Single_Line, Named_Association,");
+      Indent_Line (File, "     Single_Line, Named_Association);");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "end Put_Item;");
       New_Line (File);
    end Generate_Record;
 
-end Auto_Io_Gen.Generate.Put_Body;
+end Auto_Io_Gen.Generate.JSON_File.Put_Body;

--- a/src/json/auto_io_gen-generate-json_file-put_body.ads
+++ b/src/json/auto_io_gen-generate-json_file-put_body.ads
@@ -18,7 +18,7 @@
 
 with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate_JSON.Put_Body is
+private package Auto_Io_Gen.Generate.JSON_File.Put_Body is
    pragma Elaborate_Body; --  Ada.Text_IO, Asis
 
    procedure Generate
@@ -26,4 +26,4 @@ private package Auto_Io_Gen.Generate_JSON.Put_Body is
       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
    --  Generate body code for a Put procedure for one type.
 
-end Auto_Io_Gen.Generate_JSON.Put_Body;
+end Auto_Io_Gen.Generate.JSON_File.Put_Body;

--- a/src/json/auto_io_gen-generate-json_file-spec.adb
+++ b/src/json/auto_io_gen-generate-json_file-spec.adb
@@ -20,7 +20,7 @@ with Ada.Text_IO;
 with Asis.Aux;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate.Spec is
+package body Auto_Io_Gen.Generate.JSON_File.Spec is
 
    procedure Generate_Put_Get_Array_Spec
      (File            : in Ada.Text_IO.File_Type;
@@ -214,7 +214,6 @@ package body Auto_Io_Gen.Generate.Spec is
       is
          pragma Unreferenced (Type_List);
       begin
-         Indent_Level := 1;
          Put_Line (File, "end " & Child_Package_Name & ";");
       end Print_Footer;
 
@@ -282,7 +281,9 @@ package body Auto_Io_Gen.Generate.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association)");
+         Indent_Level := Indent_Level - 1;
       else
          Put_Line (File, ")");
       end if;
@@ -346,7 +347,9 @@ package body Auto_Io_Gen.Generate.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association)");
+         Indent_Level := Indent_Level - 1;
       else
          Put_Line (File, ")");
       end if;
@@ -402,81 +405,93 @@ package body Auto_Io_Gen.Generate.Spec is
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
-                            " Item                      : in " & Type_Name & ";",
-                            " Single_Line_Array         : in Boolean := " &
-                                                Package_Name & ".Default_Single_Line_Array;",
-                            " Named_Association_Array   : in Boolean := " &
-                                                Package_Name & ".Default_Named_Association_Array;",
-                            " Single_Line_Element       : in Boolean := " &
-                                                Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                      : in " & Type_Name & ";");
+         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
+                        Package_Name & ".Default_Single_Line_Array;");
+         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
+                        Package_Name & ".Default_Named_Association_Array;");
+         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
+                        Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                : in " & Type_Name & ";",
-                            " Single_Line_Array         : in Boolean := " &
-                                                Package_Name & ".Default_Single_Line_Array;",
-                            " Named_Association_Array   : in Boolean := " &
-                                                Package_Name & ".Default_Named_Association_Array;",
-                            " Single_Line_Element       : in Boolean := " &
-                                                Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(Item                : in " & Type_Name & ";");
+         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
+                        Package_Name & ".Default_Single_Line_Array;");
+         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
+                        Package_Name & ".Default_Named_Association_Array;");
+         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
+                        Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Put_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;",
-                            " Item                 : in " & Type_Name & ";",
-                            " Single_Line          : in Boolean := " &
-                                                Package_Name & ".Default_Single_Line_Array;",
-                            " Named_Association    : in Boolean := " &
-                                                Package_Name & ".Default_Named_Association_Array)",
-                            "renames " & Package_Name & ".Put_Item;");
+         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                 : in " & Type_Name & ";");
+         Indent_Line (File, " Single_Line          : in Boolean := " &
+                        Package_Name & ".Default_Single_Line_Array;");
+         Indent_Line (File, " Named_Association    : in Boolean := " &
+                        Package_Name & ".Default_Named_Association_Array)");
+         Indent_Line (File, "renames " & Package_Name & ".Put_Item;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
-                            " Item                      :    out " & Type_Name & ";",
-                            " Named_Association_Array   : in     Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
+         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                      :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
+         Indent_Level := Indent_Level - 1;
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level - 1;
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
-                            " Named_Association_Array   : in     Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
+         Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
+         Indent_Level := Indent_Level - 1;
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
+         Indent_Level := Indent_Level - 1;
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                            " Item              :    out " & Type_Name & ";",
-                            " Named_Association : in     Boolean := False)",
-                            "renames " & Package_Name & ".Get_Item;");
+         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item              :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association : in     Boolean := False)");
+         Indent_Line (File, "renames " & Package_Name & ".Get_Item;");
          Indent_Level := Indent_Level - 1;
 
       when Lists.Enumeration_Label =>
@@ -513,59 +528,59 @@ package body Auto_Io_Gen.Generate.Spec is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
-                         " Item                      : in " & Type_Name & ";",
-                         " Single_Line_Array         : in Boolean := False;",
-                         " Named_Association_Array   : in Boolean := False;",
-                         " Single_Line_Element       : in Boolean := True;",
-                         " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item                      : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
+      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                      : in " & Type_Name & ";",
-                         " Single_Line_Array         : in Boolean := False;",
-                         " Named_Association_Array   : in Boolean := False;",
-                         " Single_Line_Element       : in Boolean := True;",
-                         " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(Item                      : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
+      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                         " Item              : in " & Type_Name & ";",
-                         " Single_Line       : in Boolean := False;",
-                         " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line       : in Boolean := False;");
+      Indent_Line (File, " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "procedure Get");
+         Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item                      :    out " & Type_Name & ";",
-                         " Named_Association_Array   : in     Boolean := False;",
-                         " Named_Association_Element : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
-                         " Named_Association_Array   : in     Boolean := False;",
-                         " Named_Association_Element : in     Boolean := False);");
+         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                      :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "procedure Get");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "procedure Get_Item");
+         Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Type_Name & ";",
-                         " Named_Association : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item              :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association : in     Boolean := False);");
+         Indent_Level := Indent_Level - 1;
 
-      New_Line (File);
+         New_Line (File);
    end Generate_Put_Get_Derived_Array_Spec;
 
    procedure Generate_Put_Get_Private_Array_Defaults
@@ -617,58 +632,58 @@ package body Auto_Io_Gen.Generate.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                         " Item              : in " & Type_Name & ";",
-                         " Single_Line       : in Boolean := False;",
-                         " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line       : in Boolean := False;");
+      Indent_Line (File, " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "procedure Get");
+         Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item                        :    out " & Type_Name & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False);");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                        :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "procedure Get");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "procedure Get_Item");
+         Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Type_Name & ";",
-                         " Named_Association : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item              :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association : in     Boolean := False);");
+         Indent_Level := Indent_Level - 1;
 
-      New_Line (File);
+         New_Line (File);
    end Generate_Put_Get_Private_Spec;
 
    procedure Generate_Put_Get_Record_Spec
@@ -691,83 +706,83 @@ package body Auto_Io_Gen.Generate.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
-                         " Single_Line_Record          : in Boolean := True;",
-                         " Named_Association_Record    : in Boolean := False;",
-                         " Single_Line_Component       : in Boolean := True;",
-                         " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
-                         " Item              : in " & Type_Name & ";",
-                         " Single_Line       : in Boolean := False;",
-                         " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
+      Indent_Line (File, " Item              : in " & Type_Name & ";");
+      Indent_Line (File, " Single_Line       : in Boolean := False;");
+      Indent_Line (File, " Named_Association : in Boolean := False);");
 
       if Type_Descriptor.Record_Tagged then
          Indent_Level := Indent_Level - 1;
          Indent_Line (File, "procedure Put_Components");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
-                            " Item                        : in " & Type_Name & ";",
-                            " Single_Line_Record          : in Boolean := True;",
-                            " Named_Association_Record    : in Boolean := False;",
-                            " Single_Line_Component       : in Boolean := True;",
-                            " Named_Association_Component : in Boolean := False);");
+         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                        : in " & Type_Name & ";");
+         Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
+         Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
+         Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
+         Indent_Line (File, " Named_Association_Component : in Boolean := False);");
 
       end if;
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-
-      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item                        :    out " & Type_Name & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
-                         " Named_Association_Record    : in     Boolean := False;",
-                         " Named_Association_Component : in     Boolean := False);");
-
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
-
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
-                         " Item              :    out " & Type_Name & ";",
-                         " Named_Association : in     Boolean := False);");
-      Indent_Level := Indent_Level - 1;
-
-      if Type_Descriptor.Record_Tagged then
-         Indent_Line (File, "procedure Get_Components");
+         Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
-                            " Item                        :    out " & Type_Name & ";",
-                            " Named_Association_Record    : in     Boolean := False;",
-                            " Named_Association_Component : in     Boolean := False);");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item                        :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
          Indent_Level := Indent_Level - 1;
-      end if;
+         Indent_Line (File, "procedure Get");
+         Indent_Level := Indent_Level + 1;
+         Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
 
-      New_Line (File);
+         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "procedure Get_Item");
+         Indent_Level := Indent_Level + 1;
+
+         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
+         Indent_Line (File, " Item              :    out " & Type_Name & ";");
+         Indent_Line (File, " Named_Association : in     Boolean := False);");
+         Indent_Level := Indent_Level - 1;
+
+         if Type_Descriptor.Record_Tagged then
+            Indent_Line (File, "procedure Get_Components");
+            Indent_Level := Indent_Level + 1;
+
+            Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
+            Indent_Line (File, " Item                        :    out " & Type_Name & ";");
+            Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
+            Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+            Indent_Level := Indent_Level - 1;
+         end if;
+
+         New_Line (File);
    end Generate_Put_Get_Record_Spec;
 
    procedure Generate_Put_Get_Scalar_Spec
@@ -812,4 +827,4 @@ package body Auto_Io_Gen.Generate.Spec is
       New_Line (File);
    end Generate_Put_Get_Scalar_Spec;
 
-end Auto_Io_Gen.Generate.Spec;
+end Auto_Io_Gen.Generate.JSON_File.Spec;

--- a/src/json/auto_io_gen-generate-json_file-spec.ads
+++ b/src/json/auto_io_gen-generate-json_file-spec.ads
@@ -1,8 +1,8 @@
 --  Abstract :
 --
---  Generate Put procedure body for one type.
+--  Generate child package spec.
 --
---  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
+--  Copyright (C) 2001 - 2004 Stephen Leake.  All Rights Reserved.
 --
 --  This program is free software; you can redistribute it and/or
 --  modify it under terms of the GNU General Public License as
@@ -16,14 +16,19 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
-with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate.Put_Body is
-   pragma Elaborate_Body; --  Ada.Text_IO, Asis
+private package Auto_Io_Gen.Generate.JSON_File.Spec is
+   pragma Elaborate_Body;  --  Ada.Text_IO, Asis
 
-   procedure Generate
-     (File            : in Ada.Text_IO.File_Type;
-      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
-   --  Generate body code for a Put procedure for one type.
+   procedure Generate_Child_Spec
+     (File                : in Ada.Text_IO.File_Type;
+      Type_List           : in Lists.Type_Descriptor_Lists.List_Type;
+      With_List           : in Lists.Context_Trees.Tree_Type;
+      Formal_Package_List : in Lists.Formal_Package_Lists.List_Type;
+      Parent_Package_Name : in String;
+      Child_Package_Name  : in String;
+      Invisible           : in Boolean;
+      Is_Generic          : in Boolean);
+   --  Generate child package spec. File must be open for write.
 
-end Auto_Io_Gen.Generate.Put_Body;
+end Auto_Io_Gen.Generate.JSON_File.Spec;

--- a/src/json/auto_io_gen-generate-json_file.ads
+++ b/src/json/auto_io_gen-generate-json_file.ads
@@ -16,9 +16,8 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
-with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-package Auto_Io_Gen.Generate is
+package Auto_Io_Gen.Generate.JSON_File is
 --   pragma Elaborate_Body; -- Body depends on Text_IO, but this is circular due to child packages.
 
    procedure Create_Text_IO_Child
@@ -37,14 +36,15 @@ private
 
    --  Visible for child packages.
 
+
    function Ada_Text_IO return String;
    --  Return "Ada.Text_IO".
    --  TBC: Ada_83 mode was removed - candidate for removal.
 
    function Component_Type_Name
-     (Type_Element         : in Asis.Element;
-      Type_Package_Element : in Asis.Element)
-       return String;
+      (Type_Element         : in Asis.Element;
+       Type_Package_Element : in Asis.Element)
+      return String;
    --  Type_Element must be from Type_Descriptor_Type.Array_Component
    --  or Component_Type.Type_Name; Type_Package_Element must be from
    --  corresponding package element. Return appropriate type name;
@@ -63,4 +63,4 @@ private
    function Root_Type_Name (Type_Name : in String) return String;
    --  Return Type_Name without trailing _Type, if any.
 
-end Auto_Io_Gen.Generate;
+end Auto_Io_Gen.Generate.JSON_File;

--- a/src/text_io/auto_io_gen-generate-ada_file-get_body.adb
+++ b/src/text_io/auto_io_gen-generate-ada_file-get_body.adb
@@ -22,7 +22,7 @@ with Asis.Declarations;
 with Asis.Elements;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate_JSON.Get_Body is
+package body Auto_Io_Gen.Generate.Ada_File.Get_Body is
    use Ada.Text_IO;
 
    Body_First : Boolean := True; -- Shared between printing discriminants and components.
@@ -141,9 +141,7 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
          Indent_Line (File, "Get (File, Temp_Item." & Component_Name & ");");
       else
          Indent_Line (File, "Get_Item (File, Temp_Item." & Component_Name & ",");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "Named_Association => Named_Association_Component);");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, "Named_Association => Named_Association_Component);");
       end if;
 
    end Generate_Component_Temp_Get;
@@ -155,14 +153,12 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
+      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False)");
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Less (File, "is begin");
 
       if Asis.Elements.Is_Nil (Type_Descriptor.Derived_Root_Package_Declaration) then
          Indent_Line (File, "Get");
@@ -195,32 +191,22 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
       Indent_Line (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Element : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
+      Indent_Line (File, "(Item                      :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False)");
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Array, Named_Association_Element);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get_Item");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
    end Generate_Derived_Array;
 
@@ -293,9 +279,7 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
               Discriminant_Name &
               ") then");
       end if;
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "raise Discriminant_Error;");
-      Indent_Level := Indent_Level - 1;
+      Indent_More (File, "raise Discriminant_Error;");
       Indent_Line (File, "end if;");
 
    end Generate_Discriminant_Compare;
@@ -308,13 +292,12 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
    begin
       --  Generic_Array_IO was instantiated by Put_Body.
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
 
-      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
 
       Indent_Level := Indent_Level - 1;
 
@@ -337,20 +320,19 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
 
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
       Indent_Level := Indent_Level - 1;
 
       if Type_Descriptor.Array_Component_Label in Lists.Scalar_Array_Component_Labels_Type then
          Indent_Line (File, "is");
-         Indent_Line (File, "   pragma Unreferenced (Named_Association_Component);");
+         Indent_More (File, "pragma Unreferenced (Named_Association_Component);");
          Indent_Line (File, "begin");
       else
          Indent_Line (File, "is begin");
@@ -363,22 +345,17 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
       else
          Indent_Line (File, " Named_Association_Record, Named_Association_Component);");
       end if;
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
       Indent_Line (File, "procedure Get_Item");
       Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
+      Indent_Less (File, "is begin");
       Indent_Line (File, Package_Name & ".Get_Item (File, Item, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
    end Generate_Private_Array_Wrapper;
 
@@ -392,10 +369,10 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
       is begin
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                            " Named_Association_Record    : in     Boolean := False;",
+                            " Named_Association_Component : in     Boolean := False)");
 
          Indent_Level := Indent_Level - 1;
       end Print_Parameter_List;
@@ -527,9 +504,7 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
          end if;
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "begin");
-         Indent_Level := Indent_Level + 1;
+         Indent_Less (File, "begin");
 
          Body_First := True;
 
@@ -542,17 +517,14 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
          if Type_Descriptor.Record_Constrained then
             Print_Discriminant_Compares (Type_Descriptor.Record_Discriminants);
          else
-            Indent_Line (File, "declare");
-            Indent_Level := Indent_Level + 1;
+            Indent_Incr (File, "declare");
             Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name));
             Indent_Level := Indent_Level + 1;
             Indent (File, "(");
             Print_Discriminants (Type_Descriptor.Record_Discriminants);
             Put_Line (File, ");");
             Indent_Level := Indent_Level - 1;
-            Indent_Level := Indent_Level - 1;
-            Indent_Line (File, "begin");
-            Indent_Level := Indent_Level + 1;
+            Indent_Less (File, "begin");
          end if;
 
          if Type_Descriptor.Record_Derived then
@@ -568,16 +540,16 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
               (File,
                Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  ".Text_IO.Get_Components");
+            Indent_Level := Indent_Level + 1;
             Indent_Line
               (File,
                " (File, " &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Package_Name) &
                  "." &
                  Asis.Aux.Name (Type_Descriptor.Record_Parent_Type_Name) &
-                 " (Temp_Item),");
-            Indent_Line
-              (File,
+                 " (Temp_Item),",
                "Named_Association_Record, Named_Association_Component);");
+            Indent_Level := Indent_Level - 1;
          end if;
 
          if Type_Descriptor.Record_Tagged then
@@ -598,43 +570,31 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
 
          if not Type_Descriptor.Record_Constrained then
             Indent_Line (File, "Item := Temp_Item;");
-            Indent_Level := Indent_Level - 1;
-            Indent_Line (File, "end;");
+            Indent_Decr (File, "end;");
          end if;
 
          Indent_Line (File, "Check (File, "")"");");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Get;");
+         Indent_Decr (File, "end Get;");
          New_Line (File);
 
       end if;
 
-      Indent_Line (File, "procedure Get");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-      Indent_Line (File, " Named_Association_Component : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get");
+      Indent_Line (File, "(Item                        :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False)");
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (Current_Input, Item, Named_Association_Record, Named_Association_Component);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get;");
+      Indent_Decr (File, "end Get;");
       New_Line (File);
 
-      Indent_Line (File, "procedure Get_Item");
-      Indent_Level := Indent_Level + 1;
-      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";");
-      Indent_Line (File, " Named_Association : in     Boolean := False)");
-      Indent_Level := Indent_Level - 1;
-
-      Indent_Line (File, "is begin");
-      Indent_Level := Indent_Level + 1;
+      Indent_Incr (File, "procedure Get_Item");
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Lists.Type_Name (Type_Descriptor) & ";",
+                         " Named_Association : in     Boolean := False)");
+      Indent_Less (File, "is begin");
       Indent_Line (File, "Get (File, Item, Named_Association, Named_Association);");
-      Indent_Level := Indent_Level - 1;
-      Indent_Line (File, "end Get_Item;");
+      Indent_Decr (File, "end Get_Item;");
       New_Line (File);
 
       if Type_Descriptor.Record_Tagged then
@@ -642,20 +602,17 @@ package body Auto_Io_Gen.Generate_JSON.Get_Body is
          Print_Parameter_List;
 
          Indent_Line (File, "is");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, "Temp_Item : " & Asis.Aux.Name (Type_Descriptor.Type_Name) & " renames Item;");
          Indent_Line (File, "begin");
          Indent_Level := Indent_Level + 1;
 
          Body_First := True;
          Print_Component_Gets (Type_Descriptor.Record_Components);
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "end Get_Components;");
+         Indent_Decr (File, "end Get_Components;");
          New_Line (File);
       end if;
 
    end Generate_Record;
 
-end Auto_Io_Gen.Generate_JSON.Get_Body;
+end Auto_Io_Gen.Generate.Ada_File.Get_Body;

--- a/src/text_io/auto_io_gen-generate-ada_file-get_body.ads
+++ b/src/text_io/auto_io_gen-generate-ada_file-get_body.ads
@@ -1,8 +1,8 @@
 --  Abstract :
 --
---  Generate child package spec.
+--  Generate Get procedure body for one type.
 --
---  Copyright (C) 2001 - 2004 Stephen Leake.  All Rights Reserved.
+--  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
 --
 --  This program is free software; you can redistribute it and/or
 --  modify it under terms of the GNU General Public License as
@@ -16,19 +16,14 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
+with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate_Image.Spec is
-   pragma Elaborate_Body;  --  Ada.Text_IO, Asis
+private package Auto_Io_Gen.Generate.Ada_File.Get_Body is
+   pragma Elaborate_Body; --  Ada.Text_IO, Asis
 
-   procedure Generate_Child_Spec
-     (File                : in Ada.Text_IO.File_Type;
-      Type_List           : in Lists.Type_Descriptor_Lists.List_Type;
-      With_List           : in Lists.Context_Trees.Tree_Type;
-      Formal_Package_List : in Lists.Formal_Package_Lists.List_Type;
-      Parent_Package_Name : in String;
-      Child_Package_Name  : in String;
-      Invisible           : in Boolean;
-      Is_Generic          : in Boolean);
-   --  Generate child package spec. File must be open for write.
+   procedure Generate
+     (File            : in Ada.Text_IO.File_Type;
+      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
+   --  Generate body code for a Get procedure for one type.
 
-end Auto_Io_Gen.Generate_Image.Spec;
+end Auto_Io_Gen.Generate.Ada_File.Get_Body;

--- a/src/text_io/auto_io_gen-generate-ada_file-put_body.ads
+++ b/src/text_io/auto_io_gen-generate-ada_file-put_body.ads
@@ -1,6 +1,6 @@
 --  Abstract :
 --
---  Generate Get procedure body for one type.
+--  Generate Put procedure body for one type.
 --
 --  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
 --
@@ -18,12 +18,12 @@
 
 with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate.Get_Body is
+private package Auto_Io_Gen.Generate.Ada_File.Put_Body is
    pragma Elaborate_Body; --  Ada.Text_IO, Asis
 
    procedure Generate
      (File            : in Ada.Text_IO.File_Type;
       Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
-   --  Generate body code for a Get procedure for one type.
+   --  Generate body code for a Put procedure for one type.
 
-end Auto_Io_Gen.Generate.Get_Body;
+end Auto_Io_Gen.Generate.Ada_File.Put_Body;

--- a/src/text_io/auto_io_gen-generate-ada_file-spec.adb
+++ b/src/text_io/auto_io_gen-generate-ada_file-spec.adb
@@ -20,7 +20,7 @@ with Ada.Text_IO;
 with Asis.Aux;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate_JSON.Spec is
+package body Auto_Io_Gen.Generate.Ada_File.Spec is
 
    procedure Generate_Put_Get_Array_Spec
      (File            : in Ada.Text_IO.File_Type;
@@ -214,6 +214,7 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
       is
          pragma Unreferenced (Type_List);
       begin
+         Indent_Level := 1;
          Put_Line (File, "end " & Child_Package_Name & ";");
       end Print_Footer;
 
@@ -281,9 +282,7 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association)");
       else
          Put_Line (File, ")");
       end if;
@@ -347,9 +346,7 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
          --  This line gets too long for the GNAT style check. Need
          --  a general wrap mechanism, but this works for now.
          Indent_Line (File, " Named_Association : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association)");
       else
          Put_Line (File, ")");
       end if;
@@ -405,93 +402,81 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                      : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array;");
-         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                      : in " & Type_Name & ";",
+                            " Single_Line_Array         : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association_Array   : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array;",
+                            " Single_Line_Element       : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Put");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Array         : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association_Array   : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array;");
-         Indent_Line (File, " Single_Line_Element       : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Element;");
+         Indent_Line (File, "(Item                : in " & Type_Name & ";",
+                            " Single_Line_Array         : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association_Array   : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array;",
+                            " Single_Line_Element       : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Element;");
 
          --  This line gets too long for the GNAT style check.
          --  Need a general wrap mechanism, but this works for
          --  now.
          Indent_Line (File, " Named_Association_Element : in Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
 
          Indent_Line (File, "renames " & Package_Name & ".Put;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Put_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                 : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line          : in Boolean := " &
-                        Package_Name & ".Default_Single_Line_Array;");
-         Indent_Line (File, " Named_Association    : in Boolean := " &
-                        Package_Name & ".Default_Named_Association_Array)");
-         Indent_Line (File, "renames " & Package_Name & ".Put_Item;");
+         Indent_Line (File, "(File                 : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                 : in " & Type_Name & ";",
+                            " Single_Line          : in Boolean := " &
+                                                Package_Name & ".Default_Single_Line_Array;",
+                            " Named_Association    : in Boolean := " &
+                                                Package_Name & ".Default_Named_Association_Array)",
+                            "renames " & Package_Name & ".Put_Item;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
-         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                      :    out " & Type_Name & ";",
+                            " Named_Association_Array   : in     Boolean :=");
+         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Array;");
-         Indent_Level := Indent_Level - 1;
+         Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
+                            " Named_Association_Array   : in     Boolean :=");
+         Indent_More (File, Package_Name & ".Default_Named_Association_Array;");
          Indent_Line (File, " Named_Association_Element : in     Boolean :=");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, Package_Name & ".Default_Named_Association_Element)");
-         Indent_Level := Indent_Level - 1;
+         Indent_More (File, Package_Name & ".Default_Named_Association_Element)");
          Indent_Line (File, "renames " & Package_Name & ".Get;");
          Indent_Level := Indent_Level - 1;
 
          Indent_Line (File, "procedure Get_Item");
          Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item              :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association : in     Boolean := False)");
-         Indent_Line (File, "renames " & Package_Name & ".Get_Item;");
+         Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                            " Item              :    out " & Type_Name & ";",
+                            " Named_Association : in     Boolean := False)",
+                            "renames " & Package_Name & ".Get_Item;");
          Indent_Level := Indent_Level - 1;
 
       when Lists.Enumeration_Label =>
@@ -528,59 +513,59 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item                      : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(File                      : in " & Ada_Text_IO & ".File_Type;",
+                         " Item                      : in " & Type_Name & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                      : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Array         : in Boolean := False;");
-      Indent_Line (File, " Named_Association_Array   : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Element       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Element : in Boolean := False);");
+      Indent_Line (File, "(Item                      : in " & Type_Name & ";",
+                         " Single_Line_Array         : in Boolean := False;",
+                         " Named_Association_Array   : in Boolean := False;",
+                         " Single_Line_Element       : in Boolean := True;",
+                         " Named_Association_Element : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-         Indent_Line (File, "procedure Get");
-         Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                      :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Array   : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Element : in     Boolean := False);");
+      Indent_Line (File, "(File                      : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                      :    out " & Type_Name & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                      :    out " & Type_Name & ";",
+                         " Named_Association_Array   : in     Boolean := False;",
+                         " Named_Association_Element : in     Boolean := False);");
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get_Item");
-         Indent_Level := Indent_Level + 1;
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get_Item");
+      Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item              :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association : in     Boolean := False);");
-         Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
 
-         New_Line (File);
+      New_Line (File);
    end Generate_Put_Get_Derived_Array_Spec;
 
    procedure Generate_Put_Get_Private_Array_Defaults
@@ -632,58 +617,58 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-         Indent_Line (File, "procedure Get");
-         Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get_Item");
-         Indent_Level := Indent_Level + 1;
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get_Item");
+      Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item              :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association : in     Boolean := False);");
-         Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
 
-         New_Line (File);
+      New_Line (File);
    end Generate_Put_Get_Private_Spec;
 
    procedure Generate_Put_Get_Record_Spec
@@ -706,83 +691,83 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
 
       --  We should use structured comments to get the defaults for
       --  Single_Line etc.
-      Indent_Line (File, " Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, " Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(Item                        : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-      Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-      Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+      Indent_Line (File, "(Item                        : in " & Type_Name & ";",
+                         " Single_Line_Record          : in Boolean := True;",
+                         " Named_Association_Record    : in Boolean := False;",
+                         " Single_Line_Component       : in Boolean := True;",
+                         " Named_Association_Component : in Boolean := False);");
 
       Indent_Level := Indent_Level - 1;
       Indent_Line (File, "procedure Put_Item");
       Indent_Level := Indent_Level + 1;
 
-      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;");
-      Indent_Line (File, " Item              : in " & Type_Name & ";");
-      Indent_Line (File, " Single_Line       : in Boolean := False;");
-      Indent_Line (File, " Named_Association : in Boolean := False);");
+      Indent_Line (File, "(File              : in " & Ada_Text_IO & ".File_Type;",
+                         " Item              : in " & Type_Name & ";",
+                         " Single_Line       : in Boolean := False;",
+                         " Named_Association : in Boolean := False);");
 
       if Type_Descriptor.Record_Tagged then
          Indent_Level := Indent_Level - 1;
          Indent_Line (File, "procedure Put_Components");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        : in " & Type_Name & ";");
-         Indent_Line (File, " Single_Line_Record          : in Boolean := True;");
-         Indent_Line (File, " Named_Association_Record    : in Boolean := False;");
-         Indent_Line (File, " Single_Line_Component       : in Boolean := True;");
-         Indent_Line (File, " Named_Association_Component : in Boolean := False);");
+         Indent_Line (File, "(File                        : in " & Ada_Text_IO & ".File_Type;",
+                            " Item                        : in " & Type_Name & ";",
+                            " Single_Line_Record          : in Boolean := True;",
+                            " Named_Association_Record    : in Boolean := False;",
+                            " Single_Line_Component       : in Boolean := True;",
+                            " Named_Association_Component : in Boolean := False);");
 
       end if;
 
       Indent_Level := Indent_Level - 1;
       New_Line (File);
 
-         Indent_Line (File, "procedure Get");
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+
+      Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get");
+      Indent_Level := Indent_Level + 1;
+      Indent_Line (File, "(Item                        :    out " & Type_Name & ";",
+                         " Named_Association_Record    : in     Boolean := False;",
+                         " Named_Association_Component : in     Boolean := False);");
+
+      Indent_Level := Indent_Level - 1;
+      Indent_Line (File, "procedure Get_Item");
+      Indent_Level := Indent_Level + 1;
+
+      Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;",
+                         " Item              :    out " & Type_Name & ";",
+                         " Named_Association : in     Boolean := False);");
+      Indent_Level := Indent_Level - 1;
+
+      if Type_Descriptor.Record_Tagged then
+         Indent_Line (File, "procedure Get_Components");
          Indent_Level := Indent_Level + 1;
 
-         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+         Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;",
+                            " Item                        :    out " & Type_Name & ";",
+                            " Named_Association_Record    : in     Boolean := False;",
+                            " Named_Association_Component : in     Boolean := False);");
          Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get");
-         Indent_Level := Indent_Level + 1;
-         Indent_Line (File, "(Item                        :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-         Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
+      end if;
 
-         Indent_Level := Indent_Level - 1;
-         Indent_Line (File, "procedure Get_Item");
-         Indent_Level := Indent_Level + 1;
-
-         Indent_Line (File, "(File              : in     " & Ada_Text_IO & ".File_Type;");
-         Indent_Line (File, " Item              :    out " & Type_Name & ";");
-         Indent_Line (File, " Named_Association : in     Boolean := False);");
-         Indent_Level := Indent_Level - 1;
-
-         if Type_Descriptor.Record_Tagged then
-            Indent_Line (File, "procedure Get_Components");
-            Indent_Level := Indent_Level + 1;
-
-            Indent_Line (File, "(File                        : in     " & Ada_Text_IO & ".File_Type;");
-            Indent_Line (File, " Item                        :    out " & Type_Name & ";");
-            Indent_Line (File, " Named_Association_Record    : in     Boolean := False;");
-            Indent_Line (File, " Named_Association_Component : in     Boolean := False);");
-            Indent_Level := Indent_Level - 1;
-         end if;
-
-         New_Line (File);
+      New_Line (File);
    end Generate_Put_Get_Record_Spec;
 
    procedure Generate_Put_Get_Scalar_Spec
@@ -827,4 +812,4 @@ package body Auto_Io_Gen.Generate_JSON.Spec is
       New_Line (File);
    end Generate_Put_Get_Scalar_Spec;
 
-end Auto_Io_Gen.Generate_JSON.Spec;
+end Auto_Io_Gen.Generate.Ada_File.Spec;

--- a/src/text_io/auto_io_gen-generate-ada_file-spec.ads
+++ b/src/text_io/auto_io_gen-generate-ada_file-spec.ads
@@ -1,8 +1,8 @@
 --  Abstract :
 --
---  Generate Put procedure body for one type.
+--  Generate child package spec.
 --
---  Copyright (C) 2001, 2003 Stephen Leake.  All Rights Reserved.
+--  Copyright (C) 2001 - 2004 Stephen Leake.  All Rights Reserved.
 --
 --  This program is free software; you can redistribute it and/or
 --  modify it under terms of the GNU General Public License as
@@ -16,14 +16,19 @@
 --  write to the Free Software Foundation, 59 Temple Place - Suite
 --  330, Boston, MA 02111-1307, USA.
 
-with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-private package Auto_Io_Gen.Generate_Image.Put_Body is
-   pragma Elaborate_Body; --  Ada.Text_IO, Asis
+private package Auto_Io_Gen.Generate.Ada_File.Spec is
+   pragma Elaborate_Body;  --  Ada.Text_IO, Asis
 
-   procedure Generate
-     (File            : in Ada.Text_IO.File_Type;
-      Type_Descriptor : in Auto_Io_Gen.Lists.Type_Descriptor_Type);
-   --  Generate body code for a Put procedure for one type.
+   procedure Generate_Child_Spec
+     (File                : in Ada.Text_IO.File_Type;
+      Type_List           : in Lists.Type_Descriptor_Lists.List_Type;
+      With_List           : in Lists.Context_Trees.Tree_Type;
+      Formal_Package_List : in Lists.Formal_Package_Lists.List_Type;
+      Parent_Package_Name : in String;
+      Child_Package_Name  : in String;
+      Invisible           : in Boolean;
+      Is_Generic          : in Boolean);
+   --  Generate child package spec. File must be open for write.
 
-end Auto_Io_Gen.Generate_Image.Put_Body;
+end Auto_Io_Gen.Generate.Ada_File.Spec;

--- a/src/text_io/auto_io_gen-generate-ada_file.adb
+++ b/src/text_io/auto_io_gen-generate-ada_file.adb
@@ -33,7 +33,7 @@
 --  3) Record types declared in the private part: generate
 --     Private_Text_IO child package.
 --
---  4) Record types with discriminants, with no defaults. Here we call
+--  4) Record types with discriminants, with defaults. Here we call
 --     these "Constrained_Discriminants". Since the Item parameter is
 --     constrained, we can just compare the discriminants read from the
 --     file with the constraints, and raise Discriminant_Error for a
@@ -60,16 +60,19 @@
 
 with Ada.Exceptions;
 with Ada.IO_Exceptions;
-with Ada.Strings.Fixed;
+with Ada.Characters.Handling;
 with Ada.Strings.Unbounded;
+with Ada.Strings.Fixed;
 with Asis.Aux;
 with Asis.Elements;
-with Auto_Io_Gen.Generate_JSON.Get_Body;
-with Auto_Io_Gen.Generate_JSON.Put_Body;
-with Auto_Io_Gen.Generate_JSON.Spec;
+with Auto_Io_Gen.Generate.Ada_File.Get_Body;
+with Auto_Io_Gen.Generate.Ada_File.Put_Body;
+with Auto_Io_Gen.Generate.Ada_File.Spec;
 with Auto_Io_Gen.Options;
 with SAL.Gen.Alg.Process_All_Constant;
-package body Auto_Io_Gen.Generate_JSON is
+with GNAT.Source_Info;
+package body Auto_Io_Gen.Generate.Ada_File is
+   use GNAT.Source_Info;
 
    --------------
    --  Local declarations
@@ -167,6 +170,7 @@ package body Auto_Io_Gen.Generate_JSON is
          end if;
 
          Put_Line (File, "package body " & Child_Package_Name & " is");
+         Put_Line (File, "   pragma Warnings(off);");
 
          New_Line (File);
          Indent_Level := 2;
@@ -228,33 +232,27 @@ package body Auto_Io_Gen.Generate_JSON is
    is
       use Ada.Text_IO;
       use Auto_Io_Gen.Options;
-      use Ada.Strings.Unbounded;
 
-      Child_File_Name : Unbounded_String := To_Unbounded_String
-        (Options.Destination_Dir.all &
-           Options.Root_File_Name.all &
-           Options.File_Package_Separator);
 
       Child_Spec_File : File_Type; --  The output .Text_IO spec
       Child_Body_File : File_Type; --  The output .Text_IO body
 
-      Child_Package_Name : Unbounded_String := To_Unbounded_String (Parent_Package_Name) & Options.Package_Separator;
+      Child_Package_Name : constant String := Parent_Package_Name & Options.Package_Separator &
+      (if Is_Generic then "Gen_" else "" ) &
+      (if Invisible then "Private_" else "" ) & "Text_Io";
+
    begin
 
-      if Is_Generic then
-         Child_File_Name    := Child_File_Name & "gen_";
-         Child_Package_Name := Child_Package_Name & "Gen_";
+      if Options.Debug then
+         Put_Line (Enclosing_Entity & "(" & Parent_Package_Name &
+                   (if Needs_Body then ",Needs_Body" else "" ) &
+                   (if Needs_Text_IO_Utils then ",Needs_Body" else "" ) &
+                   (if Needs_Text_IO_Utils then ",Needs_Text_IO_Utils" else "" ) &
+                   (if Invisible then ",Invisible" else "" ) &
+                   (if Is_Generic then ",Is_Generic" else "" ) & ")");
       end if;
 
-      if Invisible then
-         Child_File_Name    := Child_File_Name & "private_";
-         Child_Package_Name := Child_Package_Name & "Private_";
-      end if;
-
-      Child_File_Name    := Child_File_Name & "text_io";
-      Child_Package_Name := Child_Package_Name & "Text_IO";
-
-      Create_File (Child_Spec_File, To_String (Child_File_Name & Options.Spec_File_Extension));
+      Create_File (Child_Spec_File, Ada2file  (Options.Destination_Dir.all, Child_Package_Name, Options.Spec_File_Extension));
 
       Spec.Generate_Child_Spec
         (Child_Spec_File,
@@ -262,21 +260,21 @@ package body Auto_Io_Gen.Generate_JSON is
          With_List           => Spec_With_List,
          Formal_Package_List => Formal_Package_List,
          Parent_Package_Name => Parent_Package_Name,
-         Child_Package_Name  => To_String (Child_Package_Name),
+         Child_Package_Name  => Child_Package_Name,
          Invisible           => Invisible,
          Is_Generic          => Is_Generic);
 
       Close (Child_Spec_File);
 
       if Needs_Body then
-         Create_File (Child_Body_File, To_String (Child_File_Name & Options.Body_File_Extension));
+         Create_File (Child_Body_File, Ada2file  (Options.Destination_Dir.all, Child_Package_Name, Options.Body_File_Extension));
 
          Generate_Child_Body
            (Child_Body_File,
             Type_List,
             Body_With_List,
             Parent_Package_Name => Parent_Package_Name,
-            Child_Package_Name  => To_String (Child_Package_Name),
+            Child_Package_Name  => Child_Package_Name,
             Invisible           => Invisible,
             Needs_Text_IO_Utils => Needs_Text_IO_Utils);
 
@@ -322,18 +320,8 @@ package body Auto_Io_Gen.Generate_JSON is
 
    function Instantiated_Package_Name (Type_Name : in String) return String
    is
-      Root_Name_Index : Natural := Ada.Strings.Fixed.Index (Type_Name, "_Type");
    begin
-      if Root_Name_Index = 0 then
-         --  Name does not end in "_Type", so use all of it.
-         Root_Name_Index := Type_Name'Last;
-      else
-         --  Point Root_Index to just before "_Type"
-         Root_Name_Index := Root_Name_Index - 1;
-      end if;
-
-      return Type_Name (Type_Name'First .. Root_Name_Index) & "_Text_IO";
-
+      return Type_Name & "_Impl";
    end Instantiated_Package_Name;
 
    procedure Instantiate_Generic_Array_Text_IO
@@ -444,54 +432,70 @@ package body Auto_Io_Gen.Generate_JSON is
 
    end Root_Type_Name;
 
-   function Standard_Name (Type_Name : in String) return String
-   is begin
-      return "JUNK";
-      pragma Warnings (Off);
-      if Type_Name = "boolean" then
-         return "Auto_Text_Io.Boolean_Text_IO";
+   function Ada95_Style (Lowercase_Name : in String) return String is
+      use Ada.Characters.Handling;
+      Ada95_Name : String (1 .. Lowercase_Name'Length) := Lowercase_Name;
+      I : Positive := 2;
+   begin
+      Ada95_Name (1) := To_Upper (Lowercase_Name (Lowercase_Name'First));
+      if Ada95_Name'Length < 3 then
+         return Ada95_Name;
+      end if;
+      while I < Ada95_Name'Last loop
+         if Ada95_Name (I) = '_' then
+            I := I + 1;
+            Ada95_Name (I) := To_Upper (Ada95_Name (I));
+         end if;
+         I := I + 1;
+      end loop;
+      return Ada95_Name;
+   end Ada95_Style;
 
-      elsif Type_Name = "character" then
+   function Standard_Text_IO_Name (Type_Name : in String) return String
+   is
+      use Ada.Strings.Unbounded;
+      function "+" (Unary : String) return Unbounded_String
+                                    renames To_Unbounded_String;
+      type Var_Len_Array is array (Positive range <>) of Unbounded_String;
+      Known_Types : constant Var_Len_Array
+                  := ( +"boolean",
+                       +"duration",
+                       +"float",
+                       +"integer",
+                       +"short_integer",
+                       +"short_short_integer",
+                       +"long_integer",
+                       +"long_long_integer",
+                       +"long_float",
+                       +"long_long_float" );
+   begin
+      for I in Known_Types'Range loop
+         if Type_Name = To_String (Known_Types (I)) then
+            return "Auto_Text_Io." & Ada95_Style (Type_Name) & "_Text_IO";
+         end if;
+      end loop;
+      if Type_Name = "character" then
          return "Auto_Text_Io.Text_IO";
-
-      elsif Type_Name = "duration" then
-         return "Auto_Text_Io.Duration_Text_IO";
-
-      elsif Type_Name = "float" then
-         return "Auto_Text_Io.Float_Text_IO";
-
-      elsif Type_Name = "integer" then
-         return "Auto_Text_Io.Integer_Text_IO";
-
-      elsif Type_Name = "short_integer" then
-         return "Auto_Text_Io.Short_Integer_Text_IO";
-
-      elsif Type_Name = "short_short_integer" then
-         return "Auto_Text_Io.Short_Short_Integer_Text_IO";
-
-      elsif Type_Name = "long_integer" then
-         return "Auto_Text_Io.Long_Integer_Text_IO";
-
-      elsif Type_Name = "long_long_integer" then
-         return "Auto_Text_Io.Long_Long_Integer_Text_IO";
-
-      elsif Type_Name = "long_float" then
-         return "Auto_Text_Io.Long_Float_Text_IO";
-
-      elsif Type_Name = "long_long_float" then
-         return "Auto_Text_Io.Long_Long_Float_Text_IO";
-
       elsif Type_Name = "string" then
          return "Auto_Text_Io.Text_IO";
+      elsif Type_Name = "wide_string" then
+         return "Auto_Text_Io.Wide_Text_IO";
+      elsif Type_Name = "wide_wide_string" then
+         return "Auto_Text_Io.Wide_Wide_Text_IO";
+      elsif Type_Name = "wide_character" then
+         return "Auto_Text_Io.Wide_Text_IO";
+      elsif Type_Name = "wide_wide_character" then
+         return "Auto_Text_Io.Wide_Wide_Text_IO";
       else
-         Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, "Unsuported type:  " & Type_Name);
+         Ada.Text_IO.Put_Line (Ada.Text_IO.Standard_Error, "Unsupported type:  " & Type_Name);
          raise Not_Supported with Type_Name;
       end if;
 
-   end Standard_Name;
+   end Standard_Text_IO_Name;
+
 begin
    Auto_Io_Gen.Options.Register
-     (Option => "json", Language_Name => "JSON",
+     (Option => "text_io", Language_Name => "Text_Io",
       Generator => Create_Text_IO_Child'Access,
-      Std_Names =>  Standard_Name'Access);
-end Auto_Io_Gen.Generate_JSON;
+      Std_Names =>  Standard_Text_IO_Name'Access);
+end Auto_Io_Gen.Generate.Ada_File;

--- a/src/text_io/auto_io_gen-generate-ada_file.ads
+++ b/src/text_io/auto_io_gen-generate-ada_file.ads
@@ -18,7 +18,7 @@
 
 with Ada.Text_IO;
 with Auto_Io_Gen.Lists;
-package Auto_Io_Gen.Generate_Image is
+package Auto_Io_Gen.Generate.Ada_File is
 --   pragma Elaborate_Body; -- Body depends on Text_IO, but this is circular due to child packages.
 
    procedure Create_Text_IO_Child
@@ -37,11 +37,14 @@ private
 
    --  Visible for child packages.
 
+   function Ada_Text_IO return String;
+   --  Return "Ada.Text_IO".
+   --  TBC: Ada_83 mode was removed - candidate for removal.
 
    function Component_Type_Name
-      (Type_Element         : in Asis.Element;
-       Type_Package_Element : in Asis.Element)
-      return String;
+     (Type_Element         : in Asis.Element;
+      Type_Package_Element : in Asis.Element)
+       return String;
    --  Type_Element must be from Type_Descriptor_Type.Array_Component
    --  or Component_Type.Type_Name; Type_Package_Element must be from
    --  corresponding package element. Return appropriate type name;
@@ -60,5 +63,4 @@ private
    function Root_Type_Name (Type_Name : in String) return String;
    --  Return Type_Name without trailing _Type, if any.
 
-
-end Auto_Io_Gen.Generate_Image;
+end Auto_Io_Gen.Generate.Ada_File;

--- a/src/text_io/auto_io_gen-generate.adb
+++ b/src/text_io/auto_io_gen-generate.adb
@@ -60,6 +60,8 @@
 
 with Ada.Exceptions;
 with Ada.IO_Exceptions;
+with Ada.Characters.Handling;
+with Ada.Strings.Unbounded;
 with Ada.Strings.Fixed;
 with Asis.Aux;
 with Asis.Elements;
@@ -430,41 +432,50 @@ package body Auto_Io_Gen.Generate is
 
    end Root_Type_Name;
 
+   function Ada95_Style (Lowercase_Name : in String) return String is
+      use Ada.Characters.Handling;
+      Ada95_Name : String (1 .. Lowercase_Name'Length) := Lowercase_Name;
+      I : Positive := 2;
+   begin
+      Ada95_Name (1) := To_Upper (Lowercase_Name (Lowercase_Name'First));
+      if Ada95_Name'Length < 3 then
+         return Ada95_Name;
+      end if;
+      while I < Ada95_Name'Last loop
+         if Ada95_Name (I) = '_' then
+            I := I + 1;
+            Ada95_Name (I) := To_Upper (Ada95_Name (I));
+         end if;
+         I := I + 1;
+      end loop;
+      return Ada95_Name;
+   end Ada95_Style;
+
    function Standard_Text_IO_Name (Type_Name : in String) return String
-   is begin
-      if Type_Name = "boolean" then
-         return "Auto_Text_Io.Boolean_Text_IO";
-
-      elsif Type_Name = "character" then
+   is
+      use Ada.Strings.Unbounded;
+      function "+" (Unary : String) return Unbounded_String
+                                    renames To_Unbounded_String;
+      type Var_Len_Array is array (Positive range <>) of Unbounded_String;
+      Known_Types : constant Var_Len_Array
+                  := ( +"boolean",
+                       +"duration",
+                       +"float",
+                       +"integer",
+                       +"short_integer",
+                       +"short_short_integer",
+                       +"long_integer",
+                       +"long_long_integer",
+                       +"long_float",
+                       +"long_long_float" );
+   begin
+      for I in Known_Types'Range loop
+         if Type_Name = To_String (Known_Types (I)) then
+            return "Auto_Text_Io." & Ada95_Style (Type_Name) & "_Text_IO";
+         end if;
+      end loop;
+      if Type_Name = "character" then
          return "Auto_Text_Io.Text_IO";
-
-      elsif Type_Name = "duration" then
-         return "Auto_Text_Io.Duration_Text_IO";
-
-      elsif Type_Name = "float" then
-         return "Auto_Text_Io.Float_Text_IO";
-
-      elsif Type_Name = "integer" then
-         return "Auto_Text_Io.Integer_Text_IO";
-
-      elsif Type_Name = "short_integer" then
-         return "Auto_Text_Io.Short_Integer_Text_IO";
-
-      elsif Type_Name = "short_short_integer" then
-         return "Auto_Text_Io.Short_Short_Integer_Text_IO";
-
-      elsif Type_Name = "long_integer" then
-         return "Auto_Text_Io.Long_Integer_Text_IO";
-
-      elsif Type_Name = "long_long_integer" then
-         return "Auto_Text_Io.Long_Long_Integer_Text_IO";
-
-      elsif Type_Name = "long_float" then
-         return "Auto_Text_Io.Long_Float_Text_IO";
-
-      elsif Type_Name = "long_long_float" then
-         return "Auto_Text_Io.Long_Long_Float_Text_IO";
-
       elsif Type_Name = "string" then
          return "Auto_Text_Io.Text_IO";
       elsif Type_Name = "wide_string" then


### PR DESCRIPTION
The indentation related subprograms are currently located in the root package [Auto_Io_Gen](https://github.com/okellogg/auto-io-gen/blob/master/src/auto_io_gen.ads). However, the users of these subprograms are only the code generation backends located in [text_io](https://github.com/okellogg/auto-io-gen/tree/master/src/text_io), [image](https://github.com/okellogg/auto-io-gen/tree/master/src/image), and [json](https://github.com/okellogg/auto-io-gen/tree/master/src/json).

The backends are named asymmetrically: For the [text_io](https://github.com/okellogg/auto-io-gen/tree/master/src/text_io) backend the package prefix is just `Auto_Io_Gen.Generate` whereas for e.g. the [image](https://github.com/okellogg/auto-io-gen/tree/master/src/image) backend the package prefix is `Auto_Io_Gen.Generate_Image` .

Commit 50d05d8 repurposes the package `Auto_Io_Gen.Generate` to act as the common intermediate parent package for the backends. The indentation related subprograms and the backend related function `Ada2file` are moved here.
The commit also renames the backend child packages as follows:
* The former `Auto_Io_Gen.Generate` is now named `Auto_Io_Gen.Generate.Ada_File`
* The former `Auto_Io_Gen.Generate_Image` is now named `Auto_Io_Gen.Generate.Ada_Image` 
* The former `Auto_Io_Gen.Generate_JSON` is now named `Auto_Io_Gen.Generate.JSON_File`

Commit 4308739 additionally makes a small refactoring in the `Auto_Io_Gen.Generate.Ada_File` package body function `Standard_Text_IO_Name` .
